### PR TITLE
fix: Github Actions specific fixes

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -143,7 +143,7 @@ Spectator.describe CoverageReporter::Config do
       end
     end
 
-    context "for Githab Actions" do
+    context "for Github Actions" do
       before_each do
         ENV["GITHUB_ACTIONS"] = "true"
         ENV["GITHUB_SERVER_URL"] = "https://github.com"
@@ -156,13 +156,13 @@ Spectator.describe CoverageReporter::Config do
 
       it "gets info from ENV" do
         expect(subject).to eq({
-          :repo_token         => "repo_token",
-          :service_name       => "github",
-          :service_job_number => "12345",
-          :service_job_id     => "test",
-          :service_branch     => "fix/bug",
-          :service_build_url  => "https://github.com/owner/repo/actions/runs/12345",
-          :commit_sha         => "github-commit-sha",
+          :repo_token        => "repo_token",
+          :service_name      => "github",
+          :service_number    => "12345",
+          :service_job_id    => "test",
+          :service_branch    => "fix/bug",
+          :service_build_url => "https://github.com/owner/repo/actions/runs/12345",
+          :commit_sha        => "github-commit-sha",
         })
       end
     end

--- a/src/coverage_reporter/ci/github.cr
+++ b/src/coverage_reporter/ci/github.cr
@@ -14,8 +14,8 @@ module CoverageReporter
 
         Options.new(
           service_name: "github",
+          service_number: ENV["GITHUB_RUN_ID"]?,
           service_job_id: ENV["GITHUB_JOB"]?,
-          service_job_number: ENV["GITHUB_RUN_ID"]?,
           service_branch: ENV["GITHUB_REF_NAME"]?,
           service_build_url: build_url,
           commit_sha: ENV["GITHUB_SHA"]?,

--- a/src/coverage_reporter/ci/gitlab.cr
+++ b/src/coverage_reporter/ci/gitlab.cr
@@ -10,8 +10,8 @@ module CoverageReporter
 
         Options.new(
           service_name: "gitlab-ci",
-          service_job_number: ENV["CI_JOB_ID"]? || ENV["CI_BUILD_NAME"]?,
-          service_job_id: ENV["CI_JOB_NAME"]? || ENV["CI_BUILD_ID"]?,
+          service_job_id: ENV["CI_JOB_NAME"]?,
+          service_job_number: ENV["CI_JOB_ID"]?,
           service_branch: ENV["CI_COMMIT_REF_NAME"]?,
           service_build_url: ENV["CI_JOB_URL"]?,
           commit_sha: ENV["CI_COMMIT_SHA"]?,

--- a/src/coverage_reporter/parsers/simplecov_parser.cr
+++ b/src/coverage_reporter/parsers/simplecov_parser.cr
@@ -38,12 +38,14 @@ module CoverageReporter
             coverage = info
           when LinesAndBranches
             coverage = info["lines"].as(Coverage)
-            info["branches"].as(Branches).each do |branch, branch_info|
-              branch_number = 0
-              line_number = branch.split(", ")[2].to_i64
-              branch_info.each_value do |hits|
-                branch_number += 1
-                branches.push(line_number, 0, branch_number, hits)
+            if info["branches"]?
+              info["branches"].as(Branches).each do |branch, branch_info|
+                branch_number = 0
+                line_number = branch.split(", ")[2].to_i64
+                branch_info.each_value do |hits|
+                  branch_number += 1
+                  branches.push(line_number, 0, branch_number, hits)
+                end
               end
             end
           end


### PR DESCRIPTION
**Summary:**

- [x] Remove `service_job_number` from Github Actions params. It doesn't fit into integer boundaries
- [x] Allow empty branches coverage for SimpleCov parser