### PR TITLE
feat: pass repo_name in Github Actions

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -157,6 +157,7 @@ Spectator.describe CoverageReporter::Config do
       it "gets info from ENV" do
         expect(subject).to eq({
           :repo_token        => "repo_token",
+          :repo_name         => "owner/repo",
           :service_name      => "github",
           :service_number    => "12345",
           :service_job_id    => "test",

--- a/src/coverage_reporter/api/webhook.cr
+++ b/src/coverage_reporter/api/webhook.cr
@@ -3,11 +3,9 @@ require "json"
 
 module CoverageReporter
   class Api::Webhook
-    @token : String | Nil
     @build_num : String | Nil
 
-    def initialize(config : Config)
-      @token = config.repo_token
+    def initialize(@config : Config)
       @build_num = config[:service_number]?
     end
 
@@ -16,13 +14,12 @@ module CoverageReporter
 
       Log.info "⭐️ Calling parallel done webhook: #{webhook_url}"
 
-      data = {
-        :repo_token => @token,
-        :payload    => {
+      data = @config.to_h.merge({
+        :payload => {
           :build_num => @build_num,
           :status    => "done",
         },
-      }
+      })
 
       Log.debug "---\n⛑ Debug Output:\n#{data.to_pretty_json}"
 

--- a/src/coverage_reporter/api/webhook.cr
+++ b/src/coverage_reporter/api/webhook.cr
@@ -3,10 +3,7 @@ require "json"
 
 module CoverageReporter
   class Api::Webhook
-    @build_num : String | Nil
-
     def initialize(@config : Config)
-      @build_num = config[:service_number]?
     end
 
     def send_request(dry_run : Bool = false)
@@ -16,7 +13,7 @@ module CoverageReporter
 
       data = @config.to_h.merge({
         :payload => {
-          :build_num => @build_num,
+          :build_num => @config[:service_number]?,
           :status    => "done",
         },
       })

--- a/src/coverage_reporter/ci/github.cr
+++ b/src/coverage_reporter/ci/github.cr
@@ -14,6 +14,7 @@ module CoverageReporter
 
         Options.new(
           service_name: "github",
+          repo_name: ENV["GITHUB_REPOSITORY"]?,
           service_number: ENV["GITHUB_RUN_ID"]?,
           service_job_id: ENV["GITHUB_JOB"]?,
           service_branch: ENV["GITHUB_REF_NAME"]?,

--- a/src/coverage_reporter/ci/options.cr
+++ b/src/coverage_reporter/ci/options.cr
@@ -11,7 +11,8 @@ module CoverageReporter
         @service_name : String? = nil,
         @service_number : String? = nil,
         @service_pull_request : String? = nil,
-        @commit_sha : String? = nil
+        @commit_sha : String? = nil,
+        @repo_name : String? = nil
       ); end
 
       def to_h : Hash(Symbol, String)
@@ -25,6 +26,7 @@ module CoverageReporter
           :service_number       => @service_number,
           :service_pull_request => @service_pull_request,
           :commit_sha           => @commit_sha,
+          :repo_name            => @repo_name,
         }.compact
       end
     end

--- a/src/coverage_reporter/config.cr
+++ b/src/coverage_reporter/config.cr
@@ -77,6 +77,7 @@ module CoverageReporter
         service_job_number: ENV["COVERALLS_SERVICE_JOB_NUMBER"]?.presence,
         service_branch: ENV["COVERALLS_GIT_BRANCH"]?.presence,
         commit_sha: ENV["COVERALLS_GIT_COMMIT"]?.presence,
+        repo_name: ENV["COVERALLS_REPO_NAME"]?.presence || @yaml["repo_name"]?.try(&.to_s),
       ).to_h
     end
   end


### PR DESCRIPTION
Add more parameters for simplicity (in coveralls backend) and verbosity.

- [x] Add `repo_name` in Github Actions CI
- [x] Merge config with payload in `webhook` API request