### PR TITLE
fix: correct branch name for Github Actions

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -150,7 +150,8 @@ Spectator.describe CoverageReporter::Config do
         ENV["GITHUB_REPOSITORY"] = "owner/repo"
         ENV["GITHUB_RUN_ID"] = "12345"
         ENV["GITHUB_JOB"] = "test"
-        ENV["GITHUB_REF_NAME"] = "fix/bug"
+        ENV["GITHUB_REF_NAME"] = "main"
+        ENV["GITHUB_HEAD_REF"] = "fix/bug"
         ENV["GITHUB_SHA"] = "github-commit-sha"
       end
 

--- a/src/coverage_reporter/ci/github.cr
+++ b/src/coverage_reporter/ci/github.cr
@@ -17,7 +17,7 @@ module CoverageReporter
           repo_name: ENV["GITHUB_REPOSITORY"]?,
           service_number: ENV["GITHUB_RUN_ID"]?,
           service_job_id: ENV["GITHUB_JOB"]?,
-          service_branch: ENV["GITHUB_REF_NAME"]?,
+          service_branch: ENV["GITHUB_HEAD_REF"]? || ENV["GITHUB_REF_NAME"]?,
           service_build_url: build_url,
           commit_sha: ENV["GITHUB_SHA"]?,
         ).to_h


### PR DESCRIPTION
Summary:

- Use GITHUB_HEAD_REF (is set for PRs) and GITHUB_REF_NAME (as fallback)