### PR TITLE
docs: update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install coveralls
 
 ## Usage:
 
-> See [environment variables list](./doc/configuration.md#env-variables) that control the utility behavior.
+> See also [environment variables list](./doc/configuration.md#env-variables) and [YAML config](./doc/configuration.md#yaml-config) that control the utility behavior.
 
 ```bash
 # Automatic lookup for supported reports and sending them to https://coveralls.io

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Auto-detects your coverage artifact files and CI environment to post to [Coveral
 
 ## Install
 
-**Linux**
+#### Linux
 
 ```bash
 # You can omit '-C /usr/local/bin' argument to keep it in current directory
 curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz -C /usr/local/bin
 ```
 
-**MacOS**
+#### MacOS
 
 ```bash
 brew tap coverallsapp/coveralls
@@ -153,8 +153,8 @@ make release # both
 
 # Release
 
-1. Bump version in `coverage_reporter.cr` and `shards.yml`
-2. Commit with a message `git commit --message "X.X.X: <major changes>"`
+1. Bump version in [`src/coverage_reporter.cr`](./src/coverage_reporter.cr) and [`shard.yml`](./shard.yml)
+2. Commit with a message `git commit --message "X.X.X: <short changes description>"`
 3. Create a tag `git tag --sign --annotate vX.X.X` with the same annotation as commit message
 4. Push with a tag `git push origin master --follow-tags`
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Usage: coveralls [options]
 - [ ] Pytest-Cov
 - [ ] Gcov
 
-You can add a report parser using following [simple instructions](./doc/development.md#add-coverage-format-support).
+You can add a report parser using [following instructions](./doc/development.md#add-coverage-format-support).
 
 ## Auto-Configuration Supported CIs:
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,56 @@
 
 Auto-detects your coverage artifact files and CI environment to post to [Coveralls.io](https://coveralls.io).
 
+## Install
+
+**Linux**
+
+```bash
+# You can omit '-C /usr/local/bin' argument to keep it in current directory
+curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz -C /usr/local/bin
+```
+
+**MacOS**
+
+```bash
+brew tap coverallsapp/coveralls
+brew install coveralls
+```
+
 ## Usage:
+
+```bash
+# Automatic lookup for supported reports and sending them to https://coveralls.io
+coveralls
+
+# Explicit repo token
+coveralls --repo-token=rg8ZznwNq05g3HDfknodmueeRciuiiPDE
+
+# Use concrete report file
+coveralls --file coverage/lcov.info
+
+# Use parallel reports
+coveralls --file project1/coverage/lcov.info --parallel
+coveralls --file project2/coverage/lcov.info --parallel
+# ...
+coveralls --done
+
+# Provide a job flag
+coveralls --job-flag "Unit tests"
+
+# Testing options: no real reporting, print payload
+coveralls --debug --dry-run
+```
+
+For more options see `coveralls -h/--help`
 
 ```
 $ coveralls -h
 Coveralls Coverage Reporter vX.Y.Z
-Usage coveralls [arguments]
+Usage: coveralls [options]
     -rTOKEN, --repo-token=TOKEN      Sets coveralls repo token, overrides settings in yaml or environment variable
     -cPATH, --config-path=PATH       Set the coveralls yaml config file location, will default to check '.coveralls.yml'
+    -bPATH, --base-path=PATH         Path to the root folder of the project the coverage was collected in
     -fFILENAME, --file=FILENAME      Coverage artifact file to be reported, e.g. coverage/lcov.info (detected by default)
     -jFLAG, --job-flag=FLAG          Coverage job flag name, e.g. Unit Tests
     -p, --parallel                   Set the parallel flag. Requires webhook for completion (coveralls --done).
@@ -26,6 +68,8 @@ Usage coveralls [arguments]
     -n, --no-logo                    Do not show Coveralls logo in logs
     -q, --quiet                      Suppress all output
     --debug                          Debug mode. Data being sent to Coveralls will be outputted to console.
+    --dry-run                        Dry run (no request sent)
+    -v, --version                    Show version
     -h, --help                       Show this help
 ```
 
@@ -37,20 +81,36 @@ Usage coveralls [arguments]
 - run: wget -cq https://coveralls.io/coveralls-linux.tar.gz -O - | tar -xz && ./coveralls
 ```
 
+* Github Actions workflow.yml:
+
+```yaml
+- run: curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz && ./coveralls
+  env:
+    COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Supported Coverage File Types:
 
-* Lcov
-* SimpleCov
+- [x] Lcov
+- [x] SimpleCov
+- [x] Cobertura
+- [ ] Pytest-Cov
+- [ ] Gcov
 
-Coming soon:
-
-* Pytest-Cov
-* Gcov
+You can add a report parser using following [simple instructions](./doc/development.md#add-coverage-format-support).
 
 ## Auto-Configuration Supported CIs:
 
-* CircleCI
-* Travis
+- CircleCI
+- Github Actions
+- Travis
+- Jenkins
+- GitLab
+- Semaphore
+- Wercker
+- Codeship
+- Drone
+- Buildkite
 
 [Docs on environment variables for other CI support.](https://docs.coveralls.io/supported-ci-services#insert-your-ci-here)
 
@@ -58,7 +118,9 @@ Coming soon:
 
 Set this environment variable to your instance's host:
 
-`COVERALLS_ENDPOINT=https://coveralls-enterprise.example.com`
+```
+COVERALLS_ENDPOINT=https://coveralls-enterprise.example.com
+```
 
 SSL check will be automatically disabled to allow self-signed certificates.
 
@@ -91,8 +153,9 @@ make release # both
 
 # Release
 
-1) Bump version in `coverage_reporter.cr` and `shards.yml`
-2) Commit, Push
-3) Run `make release` (Docker must be running)
-4) Create a new release on GitHub
-5) Upload `dist/coverals-mac.tar.gz` and `dist/coverals-linux.tar.gz` to the Release Attachments
+1. Bump version in `coverage_reporter.cr` and `shards.yml`
+2. Commit with a message `git commit --message "X.X.X: <major changes>"`
+3. Create a tag `git tag --sign --annotate vX.X.X` with the same annotation as commit message
+4. Push with a tag `git push origin master --follow-tags`
+
+Github release will be created automatically.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ brew install coveralls
 
 ## Usage:
 
+> See [environment variables list](./doc/configuration.md#env-variables) that control the utility behavior.
+
 ```bash
 # Automatic lookup for supported reports and sending them to https://coveralls.io
 coveralls
 
-# Explicit repo token
+# Provide explicit repo token
 coveralls --repo-token=rg8ZznwNq05g3HDfknodmueeRciuiiPDE
 
 # Use concrete report file

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -5,6 +5,8 @@
 
 ## ENV variables
 
+These variables are always used if provided.
+
 | Name                           | Description |
 | ------------------------------ | ----------- |
 | `COVERALLS_REPO_TOKEN`         | Repository token |
@@ -21,11 +23,16 @@
 
 ## YAML config
 
-Filename: `.coveralls.yml`
+This config is optional. Its values are used in favor of CI-specific options but can be overwritten with [COVERALLS_* ENVs](#env-variables).
 
 ```yml
+# .coveralls.yml
+
 # Repository token
 repo_token: abcde12345
+
+# Repository name
+repo_name: myorg/myrepo
 
 # The name of your build system
 service_name: my-ci

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -23,7 +23,9 @@ These variables are always used if provided.
 
 ## YAML config
 
-This config is optional. Its values are used in favor of CI-specific options but can be overwritten with [COVERALLS_* ENVs](#env-variables).
+This config is optional.
+
+Its values are used in favor of CI-specific options but can be overwritten with [COVERALLS_* ENVs](#env-variables).
 
 ```yml
 # .coveralls.yml

--- a/doc/development.md
+++ b/doc/development.md
@@ -90,8 +90,86 @@ dist/coveralls --repo-token=<...> --file coverage/coverage.mycov
 
 Checklist to add new CI options:
 
-- Add a module at [src/coverage_reporter/ci/](../src/coverage_reporter/ci/) and implement `.options` method.
-- Note: `.options` method should return `nil` if environment doesn't match the CI.
-- Provide as many options as you can (see [`CI::Options`](../src/coverage_reporter/ci/options.cr) for the full list).
-- Add your module to `CI_OPTIONS` tuple.
-- Write the specs for your CI options.
+1. Add a module at [src/coverage_reporter/ci/](../src/coverage_reporter/ci/) and implement `.options` method.
+
+```crystal
+# CI options template.
+#
+# src/coverage_reporter/ci/my_ci.cr
+
+require "./options"
+
+module CoverageReporter
+  module CI
+    module MyCI
+      extend self
+
+      def options
+        # NOTE: `.options` method should return `nil` if environment doesn't match the CI.
+        return unless ENV["MY_CI"]?
+
+        Options.new(
+          service_name: "my-ci",
+          service_job_id: ENV["MY_CI_JOB_ID"]?,
+          service_pull_request: ENV["MY_CI_PR_NUMBER"]?,
+          service_branch: ENV["MY_CI_GIT_BRANCH"]?,
+          commit_sha: ENV["MY_CI_COMMIT_SHA"]?,
+          # ... provide as many options as you can.
+        ).to_h
+      end
+    end
+  end
+end
+```
+
+2. Provide as many options as you can (see [`CI::Options`](../src/coverage_reporter/ci/options.cr) for the full list).
+
+3. Add your module to `CI_OPTIONS` tuple.
+
+```crystal
+# src/coverage_reporter/config.cr
+
+module CoverageReporter
+  class Config
+    CI_OPTIONS = {
+      # ...
+      MyCI,
+    }
+
+    # ...
+  end
+end
+```
+
+4. Write the specs for your CI options.
+
+```crystal
+# spec/coverage_reporter/config_spec.cr
+
+Spectator.describe CoverageReporter::Config do
+  # ...
+  describe "#to_h" do
+    # ...
+    context "for My CI" do
+      before_each do
+        ENV["MY_CI"] = "1"
+        ENV["MY_CI_GIT_BRANCH"] = "my-ci-git-branch"
+        ENV["MY_CI_JOB_ID"] = "my-ci-job-id"
+        ENV["MY_CI_COMMIT_SHA"] = "my-ci-commit-sha"
+        ENV["MY_CI_PR_NUMBER"] = "13"
+      end
+
+      it "gets info from ENV" do
+        expect(subject).to eq({
+          :repo_token           => "repo_token",
+          :service_name         => "my-ci",
+          :service_branch       => "my-ci-git-branch",
+          :service_job_id       => "my-ci-job-id",
+          :commit_sha           => "my-ci-commit-sha",
+          :service_pull_request => "13",
+        })
+      end
+    end
+  end
+end
+```

--- a/doc/development.md
+++ b/doc/development.md
@@ -40,9 +40,47 @@ end
 
 2. Add your class to `CoverageReporter::Parser::PARSERS`
 
+```crystal
+# src/coverage_reporter/parser.cr
+
+module CoverageReporter
+  class Parser
+    PARSERS = {
+      # ...
+      MyParser,
+    }
+
+    # ...
+  end
+end
+```
+
 3. Add specs
 
+```crystal
+# spec/coverage_reporter/parsers/my_parser_spec.cr
+
+require "../../spec_helper"
+
+Spectator.describe CoverageReporter::MyParser do
+  subject { described_class.new }
+
+  describe "#matches?" do
+    # ...
+  end
+
+  describe "#parse" do
+    # ...
+  end
+end
+```
+
 4. Test it
+
+```bash
+make
+dist/coveralls --repo-token=<...> --file coverage/coverage.mycov
+```
 
 ### Parser design
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -2,14 +2,47 @@
 
 > Notes for developers and maintainers
 
-## Support new coverage report format
+## Add coverage format support
 
-Checklist to add support for a new coverage report format:
+Checklist to add a parser for a coverage report format:
 
-- Add a new implementation of `CoverageReporter::BaseParser` class.
-- Add your class to `CoverageReporter::Parser::PARSERS` tuple.
-- Write the specs for your parser.
-- Test it locally.
+1. Create a parser class which inherits `CoverageReporter::BaseParser`
+
+```crystal
+# Template parser.
+#
+# src/coverage_reporter/parsers/my_parser.cr
+
+require "./base_parser"
+
+module CoverageReporter
+  class MyParser < BaseParser
+    # Use *base_path* to append to file names retrieved from the coverage report.
+    def initialize(@base_path : String)
+    end
+
+    # Returns array of globs for automatic coverage report detection.
+    def globs : Array(String)
+      ["**/*/*.mycov", "*.mycov"]
+    end
+
+    # Checks whether the *filename* can be parsed with this parser.
+    def matches?(filename : String) : Bool
+      filename.ends_with?(".mycov")
+    end
+
+    def parse(filename : String) : Array(FileReport)
+      # ... format-specific parsing
+    end
+  end
+end
+```
+
+2. Add your class to `CoverageReporter::Parser::PARSERS`
+
+3. Add specs
+
+4. Test it
 
 ### Parser design
 

--- a/src/coverage_reporter/api/jobs.cr
+++ b/src/coverage_reporter/api/jobs.cr
@@ -19,7 +19,7 @@ module CoverageReporter
                  "You must call the webhook after all jobs finish: `coveralls --done`"
       end
 
-      @source = source_files.map &.to_h
+      @source = source_files.map(&.to_h)
     end
 
     def send_request(dry_run : Bool = false)

--- a/src/coverage_reporter/config.cr
+++ b/src/coverage_reporter/config.cr
@@ -71,13 +71,13 @@ module CoverageReporter
 
     private def custom_options : Hash(Symbol, String)
       CI::Options.new(
-        service_name: ENV["COVERALLS_SERVICE_NAME"]? || @yaml["service_name"]?.try(&.to_s),
+        service_name: ENV["COVERALLS_SERVICE_NAME"]?.presence || @yaml["service_name"]?.try(&.to_s).presence,
         service_number: ENV["COVERALLS_SERVICE_NUMBER"]?.presence,
         service_job_id: ENV["COVERALLS_SERVICE_JOB_ID"]?.presence,
         service_job_number: ENV["COVERALLS_SERVICE_JOB_NUMBER"]?.presence,
         service_branch: ENV["COVERALLS_GIT_BRANCH"]?.presence,
         commit_sha: ENV["COVERALLS_GIT_COMMIT"]?.presence,
-        repo_name: ENV["COVERALLS_REPO_NAME"]?.presence || @yaml["repo_name"]?.try(&.to_s),
+        repo_name: ENV["COVERALLS_REPO_NAME"]?.presence || @yaml["repo_name"]?.try(&.to_s).presence,
       ).to_h
     end
   end

--- a/src/coverage_reporter/parsers/base_parser.cr
+++ b/src/coverage_reporter/parsers/base_parser.cr
@@ -11,15 +11,15 @@ module CoverageReporter
   #
   # module CoverageReporter
   #   class MycovParser < BaseParser
-  #     def globs
+  #     def globs : Array(String)
   #       ["**/*/*.mycov"]
   #     end
   #
-  #     def matches?(filename)
+  #     def matches?(filename : String) : Bool
   #       filename.ends_with?(".mycov")
   #     end
   #
-  #     def parse(filename)
+  #     def parse(filename : String) : Array(FileReport)
   #       # ... mycov format specific parsing
   #     end
   #   end


### PR DESCRIPTION
**Summary**:

- [x] Add installation instructions for Linux and macOS
- [x] Add usage examples
- [x] Add code templates in `doc/development.md`
- [x] Update information about supported CI and coverage formats
