### PR TITLE
fix: skip empty ENVs to prevent empty configuration

### DIFF
--- a/src/coverage_reporter/ci/github.cr
+++ b/src/coverage_reporter/ci/github.cr
@@ -17,9 +17,9 @@ module CoverageReporter
           repo_name: ENV["GITHUB_REPOSITORY"]?,
           service_number: ENV["GITHUB_RUN_ID"]?,
           service_job_id: ENV["GITHUB_JOB"]?,
-          service_branch: ENV["GITHUB_HEAD_REF"]? || ENV["GITHUB_REF_NAME"]?,
+          service_branch: ENV["GITHUB_HEAD_REF"]?.presence || ENV["GITHUB_REF_NAME"]?.presence,
           service_build_url: build_url,
-          commit_sha: ENV["GITHUB_SHA"]?,
+          commit_sha: ENV["GITHUB_SHA"]?.presence,
         ).to_h
       end
     end

--- a/src/coverage_reporter/cli/cmd.cr
+++ b/src/coverage_reporter/cli/cmd.cr
@@ -72,10 +72,10 @@ module CoverageReporter::Cli
     property filename : String?
     property repo_token : String?
     property base_path : String?
-    property job_flag_name = ENV["COVERALLS_FLAG_NAME"]?
+    property job_flag_name = ENV["COVERALLS_FLAG_NAME"]?.presence
     property config_path = CoverageReporter::YamlConfig::DEFAULT_LOCATION
     property? no_logo = false
-    property? parallel = !!(ENV["COVERALLS_PARALLEL"]? && ENV["COVERALLS_PARALLEL"] != "false")
+    property? parallel = !!(ENV["COVERALLS_PARALLEL"]?.presence && ENV["COVERALLS_PARALLEL"] != "false")
     property? parallel_done = false
     property? dry_run = false
   end


### PR DESCRIPTION
#### :zap: Summary

This change will allow for easier usage within Github Actions where we can have empty ENVs and should ignore them.
