### PR TITLE
feat: add an option to force coverage format

### DIFF
--- a/spec/coverage_reporter/parser_spec.cr
+++ b/spec/coverage_reporter/parser_spec.cr
@@ -1,9 +1,15 @@
 require "../spec_helper"
 
 Spectator.describe CoverageReporter::Parser do
+  subject { described_class.new(coverage_file, coverage_format, base_path) }
+
+  let(coverage_file) { nil }
+  let(coverage_format) { nil }
+  let(base_path) { nil }
+
   describe "#parse" do
     context "for exact file" do
-      subject { described_class.new("spec/fixtures/lcov/test.lcov", nil) }
+      let(coverage_file) { "spec/fixtures/lcov/test.lcov" }
 
       it "returns reports for one file" do
         reports = subject.parse
@@ -12,7 +18,7 @@ Spectator.describe CoverageReporter::Parser do
       end
 
       context "for non-existing file" do
-        subject { described_class.new("spec/fixtures/oops/coverage", nil) }
+        let(coverage_file) { "spec/fixtures/oops/coverage" }
 
         it "raises error" do
           expect { subject.parse }
@@ -21,7 +27,7 @@ Spectator.describe CoverageReporter::Parser do
       end
 
       context "for an unknown file format" do
-        subject { described_class.new("spec/fixtures/lcov/test.js", nil) }
+        let(coverage_file) { "spec/fixtures/lcov/test.js" }
 
         it "returns reports for one file" do
           reports = subject.parse
@@ -29,11 +35,49 @@ Spectator.describe CoverageReporter::Parser do
           expect(reports.size).to eq 0
         end
       end
+
+      context "when coverage format forced" do
+        let(coverage_format) { "lcov" }
+
+        it "returns report only for specified format" do
+          reports = subject.parse
+
+          expect(reports.size).to eq 1
+        end
+
+        context "when a file is specified" do
+          let(coverage_file) { "spec/fixtures/lcov/for-base-path-lcov" }
+          let(base_path) { "spec/fixtures/lcov" }
+
+          it "returns report only for specified file" do
+            reports = subject.parse
+
+            expect(reports.size).to eq 1
+          end
+        end
+
+        context "when another format file specified" do
+          let(coverage_file) { "spec/fixtures/gcov/main.c.gcov" }
+
+          it "returns empty report" do
+            reports = subject.parse
+
+            expect(reports.size).to eq 0
+          end
+        end
+      end
+
+      context "for unknown coverage format" do
+        let(coverage_format) { "unknown" }
+
+        it "raises error" do
+          expect { subject.parse }
+            .to raise_error(CoverageReporter::Parser::InvalidCoverageFormat)
+        end
+      end
     end
 
     context "for all files" do
-      subject { described_class.new(nil, nil) }
-
       it "returns reports for all files" do
         reports = subject.parse
 

--- a/spec/coverage_reporter/reporter_spec.cr
+++ b/spec/coverage_reporter/reporter_spec.cr
@@ -3,29 +3,31 @@ require "../spec_helper"
 Spectator.describe CoverageReporter::Reporter do
   subject do
     described_class.new(
-      coverage_file: coverage_file,
       base_path: base_path,
-      repo_token: repo_token,
-      config_path: config_path,
+      carryforward: carryforward,
       compare_ref: compare_ref,
       compare_sha: compare_sha,
-      job_flag_name: job_flag_name,
-      carryforward: carryforward,
-      parallel: parallel,
+      config_path: config_path,
+      coverage_file: coverage_file,
+      coverage_format: coverage_format,
       dry_run: false,
+      job_flag_name: job_flag_name,
       overrides: nil,
+      parallel: parallel,
+      repo_token: repo_token,
     )
   end
 
-  let(coverage_file) { nil }
   let(base_path) { nil }
-  let(repo_token) { "test-token" }
-  let(config_path) { nil }
+  let(carryforward) { nil }
   let(compare_ref) { nil }
   let(compare_sha) { nil }
+  let(config_path) { nil }
+  let(coverage_file) { nil }
+  let(coverage_format) { nil }
   let(job_flag_name) { nil }
-  let(carryforward) { nil }
   let(parallel) { false }
+  let(repo_token) { "test-token" }
 
   describe "#report" do
     let(endpoint) { "https://coveralls.io" }

--- a/src/coverage_reporter/cli/cmd.cr
+++ b/src/coverage_reporter/cli/cmd.cr
@@ -25,15 +25,16 @@ module CoverageReporter::Cli
     reporter = CoverageReporter::Reporter.new(
       base_path: opts.base_path,
       carryforward: opts.carryforward,
-      config_path: opts.config_path,
       compare_ref: opts.compare_ref,
       compare_sha: opts.compare_sha,
+      config_path: opts.config_path,
       coverage_file: opts.filename,
+      coverage_format: opts.format,
       dry_run: opts.dry_run?,
       job_flag_name: opts.job_flag_name,
+      overrides: opts.overrides,
       parallel: opts.parallel?,
       repo_token: opts.repo_token,
-      overrides: opts.overrides
     )
 
     if opts.parallel_done?
@@ -74,6 +75,7 @@ module CoverageReporter::Cli
 
   private class Opts
     property filename : String?
+    property format : String?
     property repo_token : String?
     property base_path : String?
     property carryforward : String? = ENV["COVERALLS_CARRYFORWARD_FLAGS"]?.presence
@@ -145,24 +147,36 @@ module CoverageReporter::Cli
         opts.job_flag_name = flag.presence
       end
 
-      parser.on("-cr=REF", "--compare-ref=REF", "Git branch name to compare the coverage with") do |ref|
-        opts.compare_ref = ref.presence
-      end
-
-      parser.on("-cs=SHA", "--compare-sha=SHA", "Git commit SHA to compare the coverage with") do |sha|
-        opts.compare_sha = sha.presence
-      end
-
       parser.on("-p", "--parallel", "Set the parallel flag. Requires webhook for completion (coveralls --done)") do
         opts.parallel = true
       end
 
-      parser.on("-cf", "--carryforward", "Comma-separated list of parallel job flags") do |flags|
-        opts.carryforward = flags
-      end
-
       parser.on("-d", "--done", "Call webhook after all parallel jobs (-p) done") do
         opts.parallel_done = true
+      end
+
+      parser.on("-n", "--no-logo", "Do not show Coveralls logo in logs") do
+        opts.no_logo = true
+      end
+
+      parser.on("-q", "--quiet", "Suppress all output") do
+        Log.set(Log::Level::Error)
+      end
+
+      parser.on("--format=FORMAT", "Force coverage file format, supported formats: #{Parser::PARSERS.map(&.name).join(", ")}") do |format|
+        opts.format = format.presence
+      end
+
+      parser.on("--compare-ref=REF", "Git branch name to compare the coverage with") do |ref|
+        opts.compare_ref = ref.presence
+      end
+
+      parser.on("--compare-sha=SHA", "Git commit SHA to compare the coverage with") do |sha|
+        opts.compare_sha = sha.presence
+      end
+
+      parser.on("--carryforward=FLAGS", "Comma-separated list of parallel job flags") do |flags|
+        opts.carryforward = flags
       end
 
       parser.on("--service-name=NAME", "Build service name override") do |service_name|
@@ -187,14 +201,6 @@ module CoverageReporter::Cli
 
       parser.on("--service-pull-request=NUMBER", "PR number override") do |service_pull_request|
         opts.service_pull_request = service_pull_request.presence
-      end
-
-      parser.on("-n", "--no-logo", "Do not show Coveralls logo in logs") do
-        opts.no_logo = true
-      end
-
-      parser.on("-q", "--quiet", "Suppress all output") do
-        Log.set(Log::Level::Error)
       end
 
       parser.on("--debug", "Debug mode: data being sent to Coveralls will be printed to console") do

--- a/src/coverage_reporter/parsers/base_parser.cr
+++ b/src/coverage_reporter/parsers/base_parser.cr
@@ -36,6 +36,11 @@ module CoverageReporter
   #
   # Existing parsers can be used as a reference.
   abstract class BaseParser
+    # Returns parser name which can be used to force resolve the parser.
+    def self.name : String
+      {{ @type.stringify.gsub(/(.*::)(\w+)Parser/, "\\2").downcase }}
+    end
+
     # Returns MD5 hashsum of a file.
     def self.file_digest(filename : String) : String | Nil
       return unless File.exists?(filename)

--- a/src/coverage_reporter/parsers/coveragepy_parser.cr
+++ b/src/coverage_reporter/parsers/coveragepy_parser.cr
@@ -3,6 +3,10 @@ require "sqlite3"
 
 module CoverageReporter
   class CoveragepyParser < BaseParser
+    def self.name
+      "python"
+    end
+
     QUERY = <<-SQL
     SELECT file.path, line_bits.numbits
       FROM line_bits

--- a/src/coverage_reporter/reporter.cr
+++ b/src/coverage_reporter/reporter.cr
@@ -2,17 +2,18 @@ require "./*"
 
 module CoverageReporter
   class Reporter
-    getter coverage_file,
-      base_path,
-      repo_token,
-      config_path,
+    getter base_path,
+      carryforward,
       compare_ref,
       compare_sha,
+      config_path,
+      coverage_file,
+      coverage_format,
+      dry_run,
       job_flag_name,
-      carryforward,
       overrides,
       parallel,
-      dry_run
+      repo_token
 
     class NoSourceFiles < BaseException
       def message
@@ -21,17 +22,18 @@ module CoverageReporter
     end
 
     def initialize(
-      @coverage_file : String?,
       @base_path : String?,
-      @repo_token : String?,
-      @config_path : String?,
+      @carryforward : String?,
       @compare_ref : String?,
       @compare_sha : String?,
+      @config_path : String?,
+      @coverage_file : String?,
+      @coverage_format : String?,
+      @dry_run : Bool,
       @job_flag_name : String?,
-      @carryforward : String?,
       @overrides : CI::Options?,
       @parallel : Bool,
-      @dry_run : Bool
+      @repo_token : String?
     )
     end
 
@@ -41,7 +43,11 @@ module CoverageReporter
     # If *coverage_file* is provided only its content will be parsed. Otherwise
     # current directory will be searched for all supported report formats.
     def report
-      source_files = Parser.new(coverage_file, base_path).parse
+      source_files = Parser.new(
+        coverage_file: coverage_file,
+        coverage_format: coverage_format,
+        base_path: base_path,
+      ).parse
       raise NoSourceFiles.new unless source_files.size > 0
 
       api = Api::Jobs.new(config, parallel, source_files, Git.info(config))


### PR DESCRIPTION
Closes https://github.com/coverallsapp/coverage-reporter/issues/36

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Add `--format` option which allows to force coverage format for either specified `--filename` or all files found automatically.

```
--format=FORMAT   Force coverage file format, supported formats: lcov, simplecov, cobertura, jacoco, gcov, golang, python
```

#### :ballot_box_with_check: Checklist

- [x] Add specs
