### PR TITLE
fix: jenkins ci

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -230,7 +230,8 @@ Spectator.describe CoverageReporter::Config do
     context "for Jenkins CI" do
       before_each do
         ENV["JENKINS_HOME"] = "defined"
-        ENV["BUILD_ID"] = "jenkins-number"
+        ENV["BUILD_ID"] = "jenkins-id"
+        ENV["BUILD_NUMBER"] = "jenkins-number"
         ENV["BRANCH_NAME"] = "jenkins-branch"
         ENV["ghprbPullId"] = "jenkins-pr"
       end
@@ -240,6 +241,7 @@ Spectator.describe CoverageReporter::Config do
           :repo_token           => repo_token,
           :service_name         => "jenkins",
           :service_number       => "jenkins-number",
+          :service_job_id       => "jenkins-id",
           :service_branch       => "jenkins-branch",
           :service_pull_request => "jenkins-pr",
         })

--- a/src/coverage_reporter/ci/jenkins.cr
+++ b/src/coverage_reporter/ci/jenkins.cr
@@ -10,9 +10,11 @@ module CoverageReporter
 
         Options.new(
           service_name: "jenkins",
-          service_number: ENV["BUILD_ID"]?,
+          service_number: ENV["BUILD_NUMBER"]?,
+          service_job_id: ENV["BUILD_ID"]?,
           service_branch: ENV["BRANCH_NAME"]? || ENV["CHANGE_BRANCH"]?,
           service_build_url: ENV["BUILD_URL"]?,
+          service_job_url: ENV["BUILD_URL"]?,
           service_pull_request: ENV["CHANGE_ID"]? || ENV["ghprbPullId"]?,
         ).to_h
       end


### PR DESCRIPTION
#### :zap: Summary

CI options for Jenkins were changed with recent release, but this led to issues. Returning `service_number = $BUILD_NUMBER`

#### :ballot_box_with_check: Checklist

- [x] Add specs
