### PR TITLE
fix: treat 0 as false value

### DIFF
--- a/src/coverage_reporter/cli/cmd.cr
+++ b/src/coverage_reporter/cli/cmd.cr
@@ -88,7 +88,7 @@ module CoverageReporter::Cli
 
     # Flags
     property? no_logo = false
-    property? parallel = !!(ENV["COVERALLS_PARALLEL"]?.presence && ENV["COVERALLS_PARALLEL"] != "false")
+    property? parallel = !!(ENV["COVERALLS_PARALLEL"]?.presence && !ENV["COVERALLS_PARALLEL"].in?(["false", "0"]))
     property? parallel_done = false
     property? dry_run = false
     property? debug = false


### PR DESCRIPTION
Closes https://github.com/coverallsapp/orb/pull/28

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Treat `0` as falsey value of `COVERALLS_PARALLEL`
