### PR TITLE
fix(semaphore): correct ENV variables

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -268,16 +268,25 @@ Spectator.describe CoverageReporter::Config do
     context "for Semaphore CI" do
       before_each do
         ENV["SEMAPHORE"] = "1"
-        ENV["SEMAPHORE_BUILD_NUMBER"] = "semaphore-build-number"
-        ENV["PULL_REQUEST_NUMBER"] = "semaphore-pr"
+        ENV["SEMAPHORE_WORKFLOW_ID"] = "semaphore-workflow-id"
+        ENV["SEMAPHORE_GIT_WORKING_BRANCH"] = "semaphore-branch"
+        ENV["SEMAPHORE_GIT_PR_NUMBER"] = "semaphore-pr"
+        ENV["SEMAPHORE_GIT_SHA"] = "semaphore-commit-sha"
+        ENV["SEMAPHORE_ORGANIZATION_URL"] = "https://myorg.semaphoreci.com"
+        ENV["SEMAPHORE_JOB_ID"] = "semaphore-job-id"
       end
 
       it "provides custom options" do
         expect(subject).to eq({
           :repo_token           => repo_token,
           :service_name         => "semaphore",
-          :service_job_id       => "semaphore-build-number",
+          :service_number       => "semaphore-workflow-id",
+          :service_job_id       => "semaphore-job-id",
           :service_pull_request => "semaphore-pr",
+          :service_branch       => "semaphore-branch",
+          :commit_sha           => "semaphore-commit-sha",
+          :service_build_url    => "https://myorg.semaphoreci.com/workflows/semaphore-workflow-id",
+          :service_job_url      => "https://myorg.semaphoreci.com/jobs/semaphore-job-id",
         })
       end
     end

--- a/src/coverage_reporter/ci/semaphore.cr
+++ b/src/coverage_reporter/ci/semaphore.cr
@@ -10,8 +10,13 @@ module CoverageReporter
 
         Options.new(
           service_name: "semaphore",
-          service_job_id: ENV["SEMAPHORE_BUILD_NUMBER"]?,
-          service_pull_request: ENV["PULL_REQUEST_NUMBER"]?,
+          service_number: ENV["SEMAPHORE_WORKFLOW_ID"]?,
+          service_job_id: ENV["SEMAPHORE_JOB_ID"]?,
+          service_branch: ENV["SEMAPHORE_GIT_WORKING_BRANCH"]?,
+          service_pull_request: ENV["SEMAPHORE_GIT_PR_NUMBER"]?,
+          commit_sha: ENV["SEMAPHORE_GIT_SHA"]?,
+          service_build_url: "#{ENV["SEMAPHORE_ORGANIZATION_URL"]?}/workflows/#{ENV["SEMAPHORE_WORKFLOW_ID"]?}",
+          service_job_url: "#{ENV["SEMAPHORE_ORGANIZATION_URL"]?}/jobs/#{ENV["SEMAPHORE_JOB_ID"]?}"
         ).to_h
       end
     end


### PR DESCRIPTION
and add additional options from available variables

Per [semaphore docs](https://docs.semaphoreci.com/ci-cd-environment/environment-variables/), use the correct ENV variable names.

This partially addresses #55, in that the reporter should now read the correct environment variables on Semaphore, but does not address `--service-job-id` being ignored when `--done` is present.

The only thing I'm not sure about here is the `service_build_url` and `service_job_url` semantics mapping. On semaphore, the "job" is the individual process and the "workflow" is the entire build. 