### PR TITLE
fix: substitute current dir only from the path start

### DIFF
--- a/src/coverage_reporter/file_report.cr
+++ b/src/coverage_reporter/file_report.cr
@@ -29,7 +29,7 @@ module CoverageReporter
     end
 
     private def path : String
-      Path.posix(@name.sub(Dir.current, "").split(SEPARATOR).join('/')).normalize.to_s.lstrip('/')
+      Path.posix(@name.sub(Regex.new("^#{Dir.current}"), "").split(SEPARATOR).join('/')).normalize.to_s.lstrip('/')
     end
   end
 end

--- a/src/coverage_reporter/parsers/coveragepy_parser.cr
+++ b/src/coverage_reporter/parsers/coveragepy_parser.cr
@@ -55,7 +55,7 @@ module CoverageReporter
         coverage = get_coverage(name, hits)
 
         FileReport.new(
-          name: name.sub(Dir.current, ""),
+          name: name,
           coverage: coverage,
           source_digest: BaseParser.source_digest(name),
           format: self.class.name,

--- a/src/coverage_reporter/parsers/gcov_parser.cr
+++ b/src/coverage_reporter/parsers/gcov_parser.cr
@@ -38,9 +38,8 @@ module CoverageReporter
 
           key, val = match[1..2]
           if key == "Source" && val
-            val = base_path ? File.join(base_path, val) : val
-            name = val.sub(Dir.current, "")
-            source_digest = BaseParser.source_digest(val)
+            name = base_path ? File.join(base_path, val) : val
+            source_digest = BaseParser.source_digest(name)
           end
         else
           coverage[number - 1] = case count.strip

--- a/src/coverage_reporter/parsers/lcov_parser.cr
+++ b/src/coverage_reporter/parsers/lcov_parser.cr
@@ -101,7 +101,7 @@ module CoverageReporter
       end
 
       FileReport.new(
-        name: filename.sub(Dir.current, ""),
+        name: filename,
         coverage: coverage,
         branches: branches,
         source_digest: BaseParser.source_digest(filename),

--- a/src/coverage_reporter/parsers/simplecov_parser.cr
+++ b/src/coverage_reporter/parsers/simplecov_parser.cr
@@ -52,7 +52,7 @@ module CoverageReporter
 
           reports.push(
             FileReport.new(
-              name: name.sub(Dir.current, ""),
+              name: name,
               coverage: coverage,
               branches: branches,
               source_digest: BaseParser.source_digest(name),


### PR DESCRIPTION
#### :zap: Summary

Replace `name.sub(Dir.current, "")` to `name.sub(Regex.new("^#{Dir.current}"), "")` in order to prevent accidental change in real paths.


