### PR TITLE
fix: lcov absolute paths in Windows

### DIFF
--- a/spec/coverage_reporter/cli/cmd_spec.cr
+++ b/spec/coverage_reporter/cli/cmd_spec.cr
@@ -4,12 +4,6 @@ require "../../../src/coverage_reporter/cli/cmd"
 Spectator.describe CoverageReporter::Cli do
   subject { described_class }
 
-  before_each do
-    ENV["COVERALLS_REPO_TOKEN"] = "test-token"
-  end
-
-  after_each { ENV.clear }
-
   describe ".run" do
     it "applies defaults" do
       reporter = subject.run %w(--dry-run)

--- a/src/coverage_reporter/file_report.cr
+++ b/src/coverage_reporter/file_report.cr
@@ -29,7 +29,12 @@ module CoverageReporter
     end
 
     private def path : String
-      Path.posix(@name.sub(Regex.new("^#{Dir.current}"), "").split(SEPARATOR).join('/')).normalize.to_s.lstrip('/')
+      name = @name
+      name = name.sub(Dir.current, "") if name.starts_with?(Dir.current)
+      backslash_pwd = Dir.current.split(SEPARATOR).join('/')
+      name = name.sub(backslash_pwd, "") if name.starts_with?(backslash_pwd)
+
+      Path.posix(name.split(SEPARATOR).join('/')).normalize.to_s.lstrip('/')
     end
   end
 end

--- a/src/coverage_reporter/reporter.cr
+++ b/src/coverage_reporter/reporter.cr
@@ -71,7 +71,7 @@ module CoverageReporter
 
     private def config
       @config ||= Config.new(
-        repo_token: repo_token,
+        repo_token: dry_run ? "dry-run" : repo_token,
         flag_name: job_flag_name,
         compare_ref: compare_ref,
         compare_sha: compare_sha,


### PR DESCRIPTION
Relates to https://github.com/coverallsapp/github-action/issues/169

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

Tries replacing current directory in the `name` with both variants: slashes and backslashes (important for Windows)
