### PR TITLE
fix: use Crystal 1.7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.8.1
+          crystal: 1.7.3
 
       - run: shards install --production
 
@@ -66,7 +66,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.8.1
+          crystal: 1.7.3
 
       - name: Install dependencies
         run: shards install --production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.7.3
     - name: Install dependencies
       run: shards install
     - name: Run tests
@@ -29,7 +29,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.7.3
     - name: Install dependencies
       run: shards install
     - name: Run linter
@@ -42,7 +42,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.7.3
     - run: shards install
     - run: make
     - name: Install kcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM crystallang/crystal:1.8.1-alpine
+FROM crystallang/crystal:1.7.3-alpine
 
-RUN apk add xz-dev xz-static libxml2-dev libxml2-static sqlite-dev sqlite-static
+RUN apk add sqlite-dev sqlite-static

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UUID := $(shell id -u)
 GUID := $(shell id -g)
-CRYSTAL_VERSION := 1.8.1
+CRYSTAL_VERSION := 1.7.3
 
 compile:
 	crystal build src/cli.cr -o dist/coveralls --progress

--- a/spec/coverage_reporter/cli/cmd_spec.cr
+++ b/spec/coverage_reporter/cli/cmd_spec.cr
@@ -59,7 +59,6 @@ Spectator.describe CoverageReporter::Cli do
     it "accepts --format option" do
       reporter = subject.run %w(
         --format lcov
-        --file spec/fixtures/lcov/test.lcov
         --dry-run
       )
 

--- a/src/coverage_reporter/parsers/golang_parser.cr
+++ b/src/coverage_reporter/parsers/golang_parser.cr
@@ -19,6 +19,8 @@ module CoverageReporter
       end
 
       false
+    rescue Exception
+      false
     end
 
     def parse(filename : String) : Array(FileReport)


### PR DESCRIPTION
Closes https://github.com/coverallsapp/coverage-reporter/issues/65

#### :zap: Summary

In Crystal 1.8 they use pcre2 ([PR](https://github.com/crystal-lang/crystal/pull/13084)), and it raises an exception when parsing non UTF-8 text. It's hard to find out what exactly was wrong (as said [here](https://dev.to/seesethcode/crystal-pcre2-upgrade-guide-58eo), PCRE2 devs don't remember that :thinking:), so let's leave it for the later work. This PR downgrades Crystal version where everything worked just fine.



#### :ballot_box_with_check: Checklist

- [x] Add specs
