### PR TITLE
chore: use just Crystal 1.8 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.8.1
+          crystal: 1.8
 
       - run: shards install --production
 
@@ -66,7 +66,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.8.1
+          crystal: 1.8
 
       - name: Install dependencies
         run: shards install --production

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,6 @@ jobs:
         with:
           crystal: 1.8
 
-      - name: Install dependencies
-        run: shards install --production
-
       - name: Build (Linux)
         run: make release_linux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
       uses: crystal-lang/install-crystal@v1
       with:
         crystal: 1.8
-    - run: shards install
-    - run: make
+    - run: make build
     - name: Install kcov
       run: |
         sudo apt-get update
@@ -56,4 +55,4 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ github.token }}
       run: |
         cd coverage
-        ../dist/coveralls --base-path src/coverage_reporter/
+        ../bin/coveralls --base-path src/coverage_reporter/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.8
     - name: Install dependencies
       run: shards install
     - name: Run tests
@@ -29,7 +29,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.8
     - name: Install dependencies
       run: shards install
     - name: Run linter
@@ -42,7 +42,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.8.1
+        crystal: 1.8
     - run: shards install
     - run: make
     - name: Install kcov

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UUID := $(shell id -u)
 GUID := $(shell id -g)
-CRYSTAL_VERSION := 1.8.1
+CRYSTAL_VERSION := 1.8
 
 compile:
 	crystal build src/cli.cr -o dist/coveralls --progress

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,24 @@ UUID := $(shell id -u)
 GUID := $(shell id -g)
 CRYSTAL_VERSION := 1.8
 
-compile:
-	crystal build src/cli.cr -o dist/coveralls --progress
-
-release_linux:
-	docker build . --build-arg CRYSTAL_VERSION=$(CRYSTAL_VERSION) --tag coverage-reporter:1.0
-	docker run --rm -t -v $(shell pwd):/app \
-		-w /app --user $(UUID):$(GUID) \
-		coverage-reporter:1.0 \
-		crystal build src/cli.cr -o dist/coveralls --release --static --no-debug --progress
-	cd dist && strip coveralls && tar -cvzf coveralls-linux.tar.gz coveralls
-
-release_mac:
-	crystal build src/cli.cr -o dist/coveralls --release --no-debug --progress
-	cd dist && strip coveralls && tar -cvzf coveralls-mac.tar.gz coveralls
-
-release: | release_linux release_mac
+build:
+	shards build coveralls --progress
 
 test:
 	crystal spec --order random --error-on-warnings
 
 lint:
 	bin/ameba
+
+release_linux:
+	docker build . --build-arg CRYSTAL_VERSION=$(CRYSTAL_VERSION) --tag coverage-reporter:1.0
+	docker run --rm -t -v $(shell pwd):/app \
+		-w /app --user $(UUID):$(GUID) \
+		coverage-reporter:1.0 \
+		shards build coveralls --production --release --static --no-debug --progress
+	cd bin && strip coveralls && tar -cvzf ../dist/coveralls-linux.tar.gz coveralls && cp coveralls ../dist/
+
+release: release_linux
 
 .ONESHELL:
 new_version:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,7 @@
 name: coverage-reporter
 version: 0.3.9
+crystal: ">= 1.7.2"
+license: MIT
 
 authors:
   - Jordan Oroshiba <jordan@oroshiba.me>
@@ -22,6 +24,6 @@ development_dependencies:
   crystal-kcov:
     github: vici37/crystal-kcov
 
-crystal: ">= 1.7.2"
-
-license: MIT
+targets:
+  coveralls:
+    main: src/cli.cr


### PR DESCRIPTION
#### Summary

- [x] Use just 1.8 for version
- [x] Use `shards build` instead of `crystal build`