### PR TITLE
Use build num instead of workflow id for circleci

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -128,7 +128,7 @@ Spectator.describe CoverageReporter::Config do
     context "for Circle CI" do
       before_each do
         ENV["CIRCLECI"] = "1"
-        ENV["CIRCLE_WORKFLOW_ID"] = "9"
+        ENV["CIRCLE_BUILD_NUM"] = "9"
         ENV["CI_PULL_REQUEST"] = "PR 987"
         ENV["CIRCLE_BUILD_NUM"] = "8"
         ENV["CIRCLE_BRANCH"] = "circle-branch"
@@ -153,7 +153,7 @@ Spectator.describe CoverageReporter::Config do
       # Imagine we are on Circle
       before_each do
         ENV["CIRCLECI"] = "1"
-        ENV["CIRCLE_WORKFLOW_ID"] = "circle-service-number"
+        ENV["CIRCLE_BUILD_NUM"] = "circle-service-number"
         ENV["CI_PULL_REQUEST"] = "PR 123"
         ENV["CIRCLE_BRANCH"] = "circle-branch"
         ENV["CI_BRANCH"] = "ci-branch"

--- a/src/coverage_reporter/ci/circle_ci.cr
+++ b/src/coverage_reporter/ci/circle_ci.cr
@@ -10,7 +10,7 @@ module CoverageReporter
 
         Options.new(
           service_name: "circleci",
-          service_number: ENV["CIRCLE_WORKFLOW_ID"]?,
+          service_number: ENV["CIRCLE_BUILD_NUM"]?,
           service_build_url: ENV["CIRCLE_BUILD_URL"]?,
           service_pull_request: ENV["CI_PULL_REQUEST"]? && ENV["CI_PULL_REQUEST"][/(\d+)$/, 1]?,
           service_job_number: ENV["CIRCLE_BUILD_NUM"]?,


### PR DESCRIPTION
#### :zap: Summary

This MR changes the coveralls build id to use `CIRCLE_BUILD_NUM` instead of `CIRCLE_WORKFLOW_ID` for CircleCI builds.

#### :ballot_box_with_check: Checklist

- [x] Add specs
