### PR TITLE
fix: allow no branches in simplecov format

### DIFF
--- a/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
@@ -44,5 +44,19 @@ Spectator.describe CoverageReporter::SimplecovParser do
         })
       end
     end
+
+    context "with only lines" do
+      let(filename) { "spec/fixtures/simplecov/with-only-lines.resultset.json" }
+
+      it "parses correctly" do
+        reports = subject.parse(filename)
+        expect(reports.size).to eq 1
+        expect(reports[0].to_h).to eq({
+          :name     => "home/user/app/models/user.rb",
+          :branches => [] of Int64,
+          :coverage => [nil, 1, 1, 0, nil, nil, 1, 0, nil, nil, 1, 0, 0, nil, nil, nil],
+        })
+      end
+    end
   end
 end

--- a/spec/fixtures/simplecov/with-only-lines.resultset.json
+++ b/spec/fixtures/simplecov/with-only-lines.resultset.json
@@ -1,0 +1,26 @@
+{
+  "Rspec": {
+    "coverage": {
+      "/home/user/app/models/user.rb": {
+        "lines": [
+          null,
+          1,
+          1,
+          0,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          1,
+          0,
+          0,
+          null,
+          null,
+          null
+        ]
+      }
+    }
+  }
+}

--- a/src/coverage_reporter/parsers/simplecov_parser.cr
+++ b/src/coverage_reporter/parsers/simplecov_parser.cr
@@ -11,7 +11,7 @@ module CoverageReporter
       include JSON::Serializable
 
       property lines : Coverage
-      property branches : Hash(String, Hash(String, Int64?))
+      property branches : Hash(String, Hash(String, Int64?)) | Nil
     end
 
     class Report
@@ -49,8 +49,9 @@ module CoverageReporter
             coverage = info
           when ComplexCoverage
             coverage = info.lines
-            unless info.branches.empty?
-              info.branches.each do |branch, branch_info|
+            info_branches = info.branches
+            if info_branches
+              info_branches.each do |branch, branch_info|
                 branch_number = 0
                 line_number = branch.split(", ")[2].to_i64
                 branch_info.each_value do |hits|


### PR DESCRIPTION
Closes https://github.com/coverallsapp/coverage-reporter/issues/76

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

- Make `branches` nilable

#### :ballot_box_with_check: Checklist

- [x] Add specs
