### PR TITLE
fix: don't send all files in header

### DIFF
--- a/spec/coverage_reporter/api/jobs_spec.cr
+++ b/spec/coverage_reporter/api/jobs_spec.cr
@@ -42,7 +42,6 @@ Spectator.describe CoverageReporter::Api::Jobs do
         "X-Coveralls-Reporter"         => "coverage-reporter",
         "X-Coveralls-Reporter-Version" => CoverageReporter::VERSION,
         "X-Coveralls-Coverage-Formats" => "cobertura",
-        "X-Coveralls-Files"            => "cobertura.xml",
         "X-Coveralls-Source"           => "cli",
       },
       body: {


### PR DESCRIPTION
Closes https://github.com/coverallsapp/coverage-reporter/issues/80

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

We were passing all files in a header, so its size was about 20Kb, which is not acceptable.

#### :ballot_box_with_check: Checklist

- [x] Add specs
