### PR TITLE
feat: add Xcode Cloud CI support

### DIFF
--- a/spec/coverage_reporter/config_spec.cr
+++ b/spec/coverage_reporter/config_spec.cr
@@ -498,5 +498,26 @@ Spectator.describe CoverageReporter::Config do
         })
       end
     end
+
+    context "for Xcode Cloud" do
+      before_each do
+        ENV["CI_XCODE_PROJECT"] = "/Users/coveralls/coverage-reporter"
+        ENV["CI_BUILD_NUMBER"] = "321"
+        ENV["CI_COMMIT"] = "commit-sha"
+        ENV["CI_BRANCH"] = "feature/add-xcode-ci-support"
+        ENV["CI_PULL_REQUEST_NUMBER"] = "42"
+      end
+
+      it "provides custom options" do
+        expect(subject).to eq({
+          :repo_token           => repo_token,
+          :service_name         => "xcode-cloud",
+          :service_number       => "321",
+          :service_branch       => "feature/add-xcode-ci-support",
+          :service_pull_request => "42",
+          :commit_sha           => "commit-sha",
+        })
+      end
+    end
   end
 end

--- a/src/coverage_reporter/ci/xcode_cloud.cr
+++ b/src/coverage_reporter/ci/xcode_cloud.cr
@@ -1,0 +1,21 @@
+require "./options"
+
+module CoverageReporter
+  module CI
+    module XcodeCloud
+      extend self
+
+      def options
+        return unless ENV["CI_XCODE_PROJECT"]?
+
+        Options.new(
+          service_name: "xcode-cloud",
+          service_number: ENV["CI_BUILD_NUMBER"]?,
+          commit_sha: ENV["CI_COMMIT"]?,
+          service_branch: ENV["CI_PULL_REQUEST_SOURCE_BRANCH"]? || ENV["CI_BRANCH"]?,
+          service_pull_request: ENV["CI_PULL_REQUEST_NUMBER"]?,
+        ).to_h
+      end
+    end
+  end
+end

--- a/src/coverage_reporter/config.cr
+++ b/src/coverage_reporter/config.cr
@@ -32,6 +32,7 @@ module CoverageReporter
       CI::Surf,
       CI::Wercker,
       CI::Drone,
+      CI::XcodeCloud,
       CI::Local,
     }
 


### PR DESCRIPTION
#### :zap: Summary

This PR adds a support for Xcode Cloud CI and automatically applies env variables available in Xcode Cloud.

#### :ballot_box_with_check: Checklist

- [x] Add specs
