### PR TITLE
feat: pass more params on webhook request

### DIFF
--- a/spec/coverage_reporter/api/webhook_spec.cr
+++ b/spec/coverage_reporter/api/webhook_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
 Spectator.describe CoverageReporter::Api::Webhook do
-  subject { described_class.new(config, "flag1,flag2", false, git_info) }
+  subject { described_class.new(config, "flag1,flag2", git_info) }
 
   let(config) { CoverageReporter::Config.new("token") }
   let(git_info) { {:branch => "chore/add-tests", :head => {:message => "add tests"}} }
@@ -22,7 +22,6 @@ Spectator.describe CoverageReporter::Api::Webhook do
     {
       :repo_token   => "token",
       :carryforward => "flag1,flag2",
-      :create_build => false,
       :payload      => {
         :build_num => nil,
         :status    => "done",

--- a/spec/coverage_reporter/api/webhook_spec.cr
+++ b/spec/coverage_reporter/api/webhook_spec.cr
@@ -1,9 +1,10 @@
 require "../../spec_helper"
 
 Spectator.describe CoverageReporter::Api::Webhook do
-  subject { described_class.new(config, "flag1,flag2") }
+  subject { described_class.new(config, "flag1,flag2", false, git_info) }
 
   let(config) { CoverageReporter::Config.new("token") }
+  let(git_info) { {:branch => "chore/add-tests", :head => {:message => "add tests"}} }
   let(endpoint) { "#{CoverageReporter::Config::DEFAULT_ENDPOINT}/webhook" }
 
   after_each { WebMock.reset }
@@ -21,9 +22,16 @@ Spectator.describe CoverageReporter::Api::Webhook do
     {
       :repo_token   => "token",
       :carryforward => "flag1,flag2",
+      :create_build => false,
       :payload      => {
         :build_num => nil,
         :status    => "done",
+      },
+      :git => {
+        :branch => "chore/add-tests",
+        :head   => {
+          :message => "add tests",
+        },
       },
     }.to_json
   end

--- a/spec/coverage_reporter/cli/cmd_spec.cr
+++ b/spec/coverage_reporter/cli/cmd_spec.cr
@@ -163,7 +163,6 @@ Spectator.describe CoverageReporter::Cli do
           -m
           --build-number 3
           --carryforward 1,2,3
-          --create-build
           --dry-run
         )
       end
@@ -171,7 +170,6 @@ Spectator.describe CoverageReporter::Cli do
       it "accepts --carryforward option" do
         expect(subject).to eq 0
         expect(reporter.carryforward).to eq "1,2,3"
-        expect(reporter.create_build).to eq true
         expect(reporter.overrides.try(&.to_h)).to eq({
           :service_number => "3",
         })
@@ -191,7 +189,6 @@ Spectator.describe CoverageReporter::Cli do
       it "doesn't fail" do
         expect(subject).to eq 0
         expect(reporter.carryforward).to eq nil
-        expect(reporter.create_build).to eq false
         expect(reporter.overrides.try(&.to_h)).to eq({
           :service_number => "3",
         })

--- a/spec/coverage_reporter/cli/cmd_spec.cr
+++ b/spec/coverage_reporter/cli/cmd_spec.cr
@@ -163,6 +163,7 @@ Spectator.describe CoverageReporter::Cli do
           -m
           --build-number 3
           --carryforward 1,2,3
+          --create-build
           --dry-run
         )
       end
@@ -170,6 +171,27 @@ Spectator.describe CoverageReporter::Cli do
       it "accepts --carryforward option" do
         expect(subject).to eq 0
         expect(reporter.carryforward).to eq "1,2,3"
+        expect(reporter.create_build).to eq true
+        expect(reporter.overrides.try(&.to_h)).to eq({
+          :service_number => "3",
+        })
+      end
+    end
+
+    context "without carryforward (new args)" do
+      let(options) do
+        %w(
+          done
+          -m
+          --build-number 3
+          --no-fail
+        )
+      end
+
+      it "doesn't fail" do
+        expect(subject).to eq 0
+        expect(reporter.carryforward).to eq nil
+        expect(reporter.create_build).to eq false
         expect(reporter.overrides.try(&.to_h)).to eq({
           :service_number => "3",
         })

--- a/src/coverage_reporter/api/webhook.cr
+++ b/src/coverage_reporter/api/webhook.cr
@@ -6,7 +6,6 @@ module CoverageReporter
     def initialize(
       @config : Config,
       @carryforward : String?,
-      @create_build : Bool,
       @git : Hash(Symbol, Hash(Symbol, String) | String)
     )
     end
@@ -19,7 +18,6 @@ module CoverageReporter
 
       data = @config.to_h.merge({
         :carryforward => @carryforward,
-        :create_build => @create_build,
         :payload      => {
           :build_num => @config[:service_number]?,
           :status    => "done",

--- a/src/coverage_reporter/api/webhook.cr
+++ b/src/coverage_reporter/api/webhook.cr
@@ -3,7 +3,12 @@ require "json"
 
 module CoverageReporter
   class Api::Webhook
-    def initialize(@config : Config, @carryforward : String?)
+    def initialize(
+      @config : Config,
+      @carryforward : String?,
+      @create_build : Bool,
+      @git : Hash(Symbol, Hash(Symbol, String) | String)
+    )
     end
 
     def send_request(dry_run : Bool = false)
@@ -14,10 +19,12 @@ module CoverageReporter
 
       data = @config.to_h.merge({
         :carryforward => @carryforward,
+        :create_build => @create_build,
         :payload      => {
           :build_num => @config[:service_number]?,
           :status    => "done",
         },
+        :git => @git,
       }.compact)
 
       Log.debug "---\n⛑ Debug Output:\n#{data.to_pretty_json}"

--- a/src/coverage_reporter/cli/cmd.cr
+++ b/src/coverage_reporter/cli/cmd.cr
@@ -23,8 +23,7 @@ module CoverageReporter::Cli
       overrides: opts.overrides,
       parallel: opts.parallel?,
       repo_token: opts.repo_token,
-      measure: opts.debug? || opts.measure?,
-      create_build: opts.create_build?
+      measure: opts.debug? || opts.measure?
     )
 
     if opts.parallel_done?
@@ -97,7 +96,6 @@ module CoverageReporter::Cli
     property? allow_empty = false
     property? measure = false
     property? no_fail = false
-    property? create_build = false
 
     # CI options overrides
     property service_name : String?
@@ -218,10 +216,6 @@ module CoverageReporter::Cli
 
         parser.on("--attempt", "Run attempt number") do |attempt|
           opts.service_attempt = attempt
-        end
-
-        parser.on("--create-build", "Create a build if it wasn't yet created") do
-          opts.create_build = true
         end
 
         parser.on("-m", "--measure", "Measure time for parsing and HTTP requests") do

--- a/src/coverage_reporter/cli/cmd.cr
+++ b/src/coverage_reporter/cli/cmd.cr
@@ -24,6 +24,7 @@ module CoverageReporter::Cli
       parallel: opts.parallel?,
       repo_token: opts.repo_token,
       measure: opts.debug? || opts.measure?,
+      create_build: opts.create_build?
     )
 
     if opts.parallel_done?
@@ -96,6 +97,7 @@ module CoverageReporter::Cli
     property? allow_empty = false
     property? measure = false
     property? no_fail = false
+    property? create_build = false
 
     # CI options overrides
     property service_name : String?
@@ -216,6 +218,10 @@ module CoverageReporter::Cli
 
         parser.on("--attempt", "Run attempt number") do |attempt|
           opts.service_attempt = attempt
+        end
+
+        parser.on("--create-build", "Create a build if it wasn't yet created") do
+          opts.create_build = true
         end
 
         parser.on("-m", "--measure", "Measure time for parsing and HTTP requests") do

--- a/src/coverage_reporter/reporter.cr
+++ b/src/coverage_reporter/reporter.cr
@@ -16,7 +16,8 @@ module CoverageReporter
       overrides : CI::Options? = nil,
       parallel : Bool = false,
       repo_token : String? = nil,
-      measure : Bool = false
+      measure : Bool = false,
+      create_build : Bool = false
 
     class NoSourceFiles < BaseException
       def message
@@ -63,7 +64,12 @@ module CoverageReporter
     # from a CI-specific ENV, or can be set explicitly via `COVERALLS_SERVICE_NUMBER`
     # environment variable.
     def parallel_done
-      api = Api::Webhook.new(config, settings.carryforward || config.carryforward)
+      api = Api::Webhook.new(
+        config: config,
+        carryforward: settings.carryforward || config.carryforward,
+        create_build: settings.create_build,
+        git: Git.info(config)
+      )
 
       measure("Webhook request") do
         api.send_request(settings.dry_run)

--- a/src/coverage_reporter/reporter.cr
+++ b/src/coverage_reporter/reporter.cr
@@ -16,8 +16,7 @@ module CoverageReporter
       overrides : CI::Options? = nil,
       parallel : Bool = false,
       repo_token : String? = nil,
-      measure : Bool = false,
-      create_build : Bool = false
+      measure : Bool = false
 
     class NoSourceFiles < BaseException
       def message
@@ -67,7 +66,6 @@ module CoverageReporter
       api = Api::Webhook.new(
         config: config,
         carryforward: settings.carryforward || config.carryforward,
-        create_build: settings.create_build,
         git: Git.info(config)
       )
 


### PR DESCRIPTION
#### :zap: Summary

This PR adds more info to webhook request - git information. This allows to create a new build (with all required information) with previous jobs carry-forwarded via the following command:

```bash
coveralls done --build-number 123 --carryforward all
```

NOTE: build-number must be different from the previously reported build. Otherwise no new builds will be created.

#### :ballot_box_with_check: Checklist

- [x] Add specs
