### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ To get started you will need crystal [installed](https://crystal-lang.org/instal
 
 ```bash
 shards install
-make # bin/coverals will be created
+make # bin/coveralls will be created
 ```
 
 Run specs:


### PR DESCRIPTION
#### :zap: Summary

Fix typo of "coverals" -> "coveralls"

