### PR TITLE
Correct value for --format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ With values used for `--format` option:
 - [x] Golang coverage format - `golang`
 - [x] Coveralls JSON format - `coveralls`
 - [x] Pytest-Cov ([:test_tube: beta](#pytest-cov-test_tube-beta)) - `python`
-- [x] Clover XML - `phpunit`
+- [x] Clover XML as available via PHPUnit - `clover`
 
 You can add a report parser to this project by following [these instructions](./doc/development.md#add-coverage-format-support).
 


### PR DESCRIPTION
#### :zap: Summary

Corrects `--format` value for CloverXML / PHPUnit. Should be `clover` instead of `phpunit`.

#### :ballot_box_with_check: Checklist

- [x] Correct `--format` value for CloverXML / PHPUnit
