### PR TITLE
Remove restriction on file extension for some parsers

### DIFF
--- a/spec/coverage_reporter/parser_spec.cr
+++ b/spec/coverage_reporter/parser_spec.cr
@@ -9,12 +9,94 @@ Spectator.describe CoverageReporter::Parser do
 
   describe "#parse" do
     context "for exact file" do
-      let(coverage_files) { ["spec/fixtures/lcov/test.lcov"] }
+      context "clover" do
+        let(coverage_files) { ["spec/fixtures/clover/clover-unleash.xml"] }
 
-      it "returns reports for one file" do
-        reports = subject.parse
+        it "returns reports for one file" do
+          reports = subject.parse
 
-        expect(reports.size).to eq 2
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "cobertura" do
+        let(coverage_files) { ["spec/fixtures/cobertura/cobertura.xml"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "jacoco" do
+        let(coverage_files) { ["spec/fixtures/jacoco/jacoco-report.xml"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "golang" do
+        let(coverage_files) { ["spec/fixtures/golang/coverage.out"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "python" do
+        let(coverage_files) { ["spec/fixtures/python/.coverage"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "coveralls" do
+        let(coverage_files) { ["spec/fixtures/coveralls/coveralls.json"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "lcov" do
+        let(coverage_files) { ["spec/fixtures/lcov/test.lcov"] }
+
+        it "returns reports for one file" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "simplecov" do
+        let(coverage_files) { ["spec/fixtures/simplecov/with-only-lines.resultset.json"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
+      end
+
+      context "gcov" do
+        let(coverage_files) { ["spec/fixtures/gcov/main.c.gcov"] }
+
+        it "returns reports" do
+          reports = subject.parse
+
+          expect(reports.size).to be > 0
+        end
       end
 
       context "for non-existing file" do
@@ -37,6 +119,7 @@ Spectator.describe CoverageReporter::Parser do
       end
 
       context "when coverage format forced (lcov)" do
+        let(coverage_files) { ["spec/fixtures/lcov/test.lcov"] }
         let(coverage_format) { "lcov" }
 
         it "returns report only for specified format" do
@@ -97,6 +180,7 @@ Spectator.describe CoverageReporter::Parser do
       end
 
       context "for unknown coverage format" do
+        let(coverage_files) { ["spec/fixtures/lcov/test.lcov"] }
         let(coverage_format) { "unknown" }
 
         it "raises error" do

--- a/spec/coverage_reporter/parsers/gcov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/gcov_parser_spec.cr
@@ -14,11 +14,14 @@ Spectator.describe CoverageReporter::GcovParser do
   end
 
   describe "#matches?" do
-    it "is always true" do
+    it "is true except for lcov and simplecov extensions" do
       expect(subject.matches?(".gcov")).to eq true
       expect(subject.matches?("main.c.gcov")).to eq true
       expect(subject.matches?("some-path/file.gcov")).to eq true
-      expect(subject.matches?("main.c.lcov")).to eq true
+
+      expect(subject.matches?("main.c.lcov")).to eq false
+      expect(subject.matches?("lcov.info")).to eq false
+      expect(subject.matches?("path/to/file.resultset.json")).to be false
     end
   end
 

--- a/spec/coverage_reporter/parsers/gcov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/gcov_parser_spec.cr
@@ -14,11 +14,11 @@ Spectator.describe CoverageReporter::GcovParser do
   end
 
   describe "#matches?" do
-    it "matches only .gcov files" do
+    it "is always true" do
       expect(subject.matches?(".gcov")).to eq true
       expect(subject.matches?("main.c.gcov")).to eq true
       expect(subject.matches?("some-path/file.gcov")).to eq true
-      expect(subject.matches?("main.c.lcov")).to eq false
+      expect(subject.matches?("main.c.lcov")).to eq true
     end
   end
 

--- a/spec/coverage_reporter/parsers/lcov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/lcov_parser_spec.cr
@@ -17,10 +17,10 @@ Spectator.describe CoverageReporter::LcovParser do
   end
 
   describe "#matches?" do
-    it "matches correct filenames" do
+    it "is always true" do
       expect(subject.matches?("somefile.lcov")).to eq true
       expect(subject.matches?("long/path/to/file.lcov")).to eq true
-      expect(subject.matches?("long/path/to/file.lco")).to eq false
+      expect(subject.matches?("long/path/to/file.lco")).to eq true
 
       expect(subject.matches?("lcov.info")).to eq true
       expect(subject.matches?("long/path/to/lcov.info")).to eq true

--- a/spec/coverage_reporter/parsers/lcov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/lcov_parser_spec.cr
@@ -17,7 +17,7 @@ Spectator.describe CoverageReporter::LcovParser do
   end
 
   describe "#matches?" do
-    it "is always true" do
+    it "is true except for gcov and simplecov extensions" do
       expect(subject.matches?("somefile.lcov")).to eq true
       expect(subject.matches?("long/path/to/file.lcov")).to eq true
       expect(subject.matches?("long/path/to/file.lco")).to eq true
@@ -25,6 +25,9 @@ Spectator.describe CoverageReporter::LcovParser do
       expect(subject.matches?("lcov.info")).to eq true
       expect(subject.matches?("long/path/to/lcov.info")).to eq true
       expect(subject.matches?("heylcov.info")).to eq true
+
+      expect(subject.matches?("main.c.gcov")).to be false
+      expect(subject.matches?("path/to/file.resultset.json")).to be false
     end
   end
 

--- a/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
@@ -12,8 +12,8 @@ Spectator.describe CoverageReporter::SimplecovParser do
   end
 
   describe "#matches?" do
-    it "matches correct filenames" do
-      expect(subject.matches?(".resultset.jsonb")).to eq false
+    it "is always true" do
+      expect(subject.matches?(".resultset.jsonb")).to eq true
       expect(subject.matches?(".resultset.json")).to eq true
       expect(subject.matches?("path/to/.resultset.json")).to eq true
       expect(subject.matches?("path/to/file.resultset.json")).to eq true

--- a/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/simplecov_parser_spec.cr
@@ -12,11 +12,15 @@ Spectator.describe CoverageReporter::SimplecovParser do
   end
 
   describe "#matches?" do
-    it "is always true" do
+    it "is true except for lcov and gcov extensions" do
       expect(subject.matches?(".resultset.jsonb")).to eq true
       expect(subject.matches?(".resultset.json")).to eq true
       expect(subject.matches?("path/to/.resultset.json")).to eq true
       expect(subject.matches?("path/to/file.resultset.json")).to eq true
+
+      expect(subject.matches?("some-path/file.gcov")).to eq false
+      expect(subject.matches?("main.c.lcov")).to eq false
+      expect(subject.matches?("lcov.info")).to eq false
     end
   end
 

--- a/src/coverage_reporter/parser.cr
+++ b/src/coverage_reporter/parser.cr
@@ -16,15 +16,15 @@ module CoverageReporter
     # A list of available parsers.
     # See `CoverageReporter::BaseParser` for details.
     PARSERS = {
-      LcovParser,
-      SimplecovParser,
       CloverParser,
       CoberturaParser,
       JacocoParser,
-      GcovParser,
       GolangParser,
       CoveragepyParser,
       CoverallsParser,
+      LcovParser,
+      SimplecovParser,
+      GcovParser,
     }
 
     class NotFound < BaseException

--- a/src/coverage_reporter/parsers/gcov_parser.cr
+++ b/src/coverage_reporter/parsers/gcov_parser.cr
@@ -16,7 +16,7 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      filename.ends_with?(".gcov")
+      true
     end
 
     def parse(filename : String) : Array(FileReport)

--- a/src/coverage_reporter/parsers/gcov_parser.cr
+++ b/src/coverage_reporter/parsers/gcov_parser.cr
@@ -16,7 +16,8 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      true
+      !filename.ends_with?(".resultset.json") &&
+        !filename.ends_with?(".lcov") && !filename.ends_with?("lcov.info")
     end
 
     def parse(filename : String) : Array(FileReport)

--- a/src/coverage_reporter/parsers/lcov_parser.cr
+++ b/src/coverage_reporter/parsers/lcov_parser.cr
@@ -23,7 +23,7 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      filename.ends_with?(".lcov") || filename.ends_with?("lcov.info")
+      true
     end
 
     def parse(filename : String) : Array(FileReport)

--- a/src/coverage_reporter/parsers/lcov_parser.cr
+++ b/src/coverage_reporter/parsers/lcov_parser.cr
@@ -23,7 +23,7 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      true
+      !filename.ends_with?(".resultset.json") && !filename.ends_with?(".gcov")
     end
 
     def parse(filename : String) : Array(FileReport)

--- a/src/coverage_reporter/parsers/simplecov_parser.cr
+++ b/src/coverage_reporter/parsers/simplecov_parser.cr
@@ -31,7 +31,7 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      filename.ends_with?(".resultset.json")
+      true
     end
 
     def parse(filename : String) : Array(FileReport)

--- a/src/coverage_reporter/parsers/simplecov_parser.cr
+++ b/src/coverage_reporter/parsers/simplecov_parser.cr
@@ -31,7 +31,8 @@ module CoverageReporter
     end
 
     def matches?(filename : String) : Bool
-      true
+      !filename.ends_with?(".gcov") &&
+        !filename.ends_with?(".lcov") && !filename.ends_with?("lcov.info")
     end
 
     def parse(filename : String) : Array(FileReport)


### PR DESCRIPTION
Problem
--------
All files are now run through a parser's `matches?`
method, which is causing issues for the lcov,
gcov, and simplecov parsers since the
`matches?` method checks that files have a
particular file extension. This is causing failures
when users pass a custom file.

Solution
--------
The lcov, gcov, and simplecov parsers were moved
to the last in the array of parsers, since they are
the only parsers which do not check actual
file contents to see if a file is of the correct 
format. In order to ensure that these three
parsers will not erroneously match on files of
the other two types, we modify the `matches?`
method to return false if file extensions of the
other two parsers are matched. 

If a user is passing a custom gcov, simplecov, or
lcov parser with a non-standard file extension, then
they must specify the `--format` parameter.

If the user does not specify a custom file, then
only files that match the extensions formerly listed
in the `matches?` method will be returned anyway
due to the `globs` method.

Closes #127 