### PR TITLE
GitHub Actions example: GitHub token is required for v2

### DIFF
--- a/doc/examples/github-actions-default.yml
+++ b/doc/examples/github-actions-default.yml
@@ -22,3 +22,5 @@ jobs:
 
     - name: Report Coveralls
       uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
💁 A GitHub token is required to use the [Coveralls GitHub Action](https://github.com/coverallsapp/github-action) as of version 2. This change corrects the example to reflect that.