### PR TITLE
Update Crystal Lang version to 1.13.1, the latest stable version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.9
+          crystal: 1.13.1
 
       - name: Build SQLite3 static library
         run: "scripts/sqlite3-static.ps1"
@@ -72,7 +72,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.9
+          crystal: 1.13.1
 
       - name: Build (Linux)
         run: make release_linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.9
+        crystal: 1.13.1
     - name: Install dependencies
       run: shards install
     - name: Install coverage.py
@@ -34,7 +34,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.9
+        crystal: 1.13.1
     - name: Install dependencies
       run: shards install
     - name: Run linter
@@ -47,7 +47,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.9
+        crystal: 1.13.1
     - run: make build
     - name: Install kcov
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UUID := $(shell id -u)
 GUID := $(shell id -g)
-CRYSTAL_VERSION := 1.9
+CRYSTAL_VERSION := 1.13.1
 
 build:
 	shards build coveralls --progress --error-trace


### PR DESCRIPTION
#### :zap: Summary

- Updates **Crystal lang version** from `1.9.1` to `1.13.1` (latest stable version).
- **Crystal** `1.13.1` has better support for mutliple architectures including `aarch64`.
  -  Our next release of `coverage-reporter` after this one requires support for `aarch64` and will therefore need to cross-compile **two** (**2**) **linux binaries** for: 
      1. `x86_64` 
      2. `aarch64`.

#### :ballot_box_with_check: Checklist

- [x] Update Crystal version in `.github/workflows/build.yml`, `.github/workflows/ci.yml` & `Makefile`
