### PR TITLE
Modify Makefile to fix issues with sed handling inputs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,11 @@ release: release_linux
 
 .ONESHELL:
 new_version:
-	@read -p "New version: " version
-	@read -p "Brief description: " description
-	sed -i "s/version:.*/version: $$version/" shard.yml
-	sed -i "s/VERSION = ".*"/VERSION = \"$$version\"/" src/coverage_reporter.cr
-	git add shard.yml src/coverage_reporter.cr
-	git commit --message "$$version: $$description"
-	git tag --annotate --message "$$version: $$description" v$$version
+	@read -p "New version: " version; \
+	@read -p "Brief description: " description; \
+	sed -i '' "s/version:.*/version: $${version}/" shard.yml; \
+	sed -i '' "s/VERSION = .*/VERSION = \"$${version}\"/" src/coverage_reporter.cr; \
+	git add shard.yml src/coverage_reporter.cr; \
+	git commit --message "$${version}: $${description}"; \
+	git tag --annotate v$${version} --message "$${version}: $${description}"; \
+	git push origin master --follow-tags

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,11 @@ release: release_linux
 .ONESHELL:
 new_version:
 	@read -p "New version: " version; \
-	@read -p "Brief description: " description; \
+	read -p "Brief description: " description; \
+	echo "Version: $$version"; \
+	echo "Description: $$description"; \
 	sed -i '' "s/version:.*/version: $${version}/" shard.yml; \
-	sed -i '' "s/VERSION = .*/VERSION = \"$${version}\"/" src/coverage_reporter.cr; \
+	sed -i '' "s/VERSION = .*/VERSION = \"$$version\"/" src/coverage_reporter.cr; \
 	git add shard.yml src/coverage_reporter.cr; \
 	git commit --message "$${version}: $${description}"; \
 	git tag --annotate v$${version} --message "$${version}: $${description}"; \


### PR DESCRIPTION
#### :zap: Summary

- Modify Makefile to fix issues with sed handling inputs.
- Prior to changes, `make new_version` was throwing errors like this:

```bash
% make new_version
New version: 0.6.13
Brief description: Update Crystal lang version to 1.13.1
sed -i "s/version:.*/version: $version/" shard.yml
sed: 1: "shard.yml": unterminated substitute pattern
make: *** [new_version] Error 1
```

#### :ballot_box_with_check: Checklist

- [x] Modify Makefile 🤞 
