### PR TITLE
Update `build.yml` workflow to cross-compile linux binaries for `x86_64` and `aarch64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Build x86_64 binary
         run: |
           docker buildx build \
+            --no-cache \
             --platform linux/amd64 \
             --build-arg CRYSTAL_VERSION=1.13.1 \
             --target x86_64_binary \
@@ -87,6 +88,7 @@ jobs:
       - name: Build aarch64 binary
         run: |
           docker buildx build \
+            --no-cache \
             --platform linux/arm64 \
             --build-arg CRYSTAL_VERSION=1.13.1 \
             --target aarch64_binary \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-medium
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-m
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -51,14 +51,14 @@ jobs:
           tar -acf coveralls-windows.zip coveralls.exe
 
       - name: Upload exe
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-windows.exe
           path: dist/coveralls.exe
           if-no-files-found: error
 
       - name: Upload zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-windows.zip
           path: dist/coveralls-windows.zip
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04-2xlarge
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker BuildX
         run: |
@@ -104,42 +104,42 @@ jobs:
           tar -czf coveralls-linux-aarch64.tar.gz coveralls-linux-aarch64
           
       - name: Upload generic linux binary (x86_64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux
           path: dist/coveralls-linux
           if-no-files-found: error
 
       - name: Upload generic linux (x86_64) tar.gz archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux.tar.gz
           path: dist/coveralls-linux.tar.gz
           if-no-files-found: error
 
       - name: Upload x86_64-specific binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux-x86_64
           path: dist/coveralls-linux-x86_64
           if-no-files-found: error
 
       - name: Upload x86_64-specific tar.gz archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux-x86_64.tar.gz
           path: dist/coveralls-linux-x86_64.tar.gz
           if-no-files-found: error
 
       - name: Upload aarch64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux-aarch64
           path: dist/coveralls-linux-aarch64
           if-no-files-found: error
 
       - name: Upload aarch64 tar.gz archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux-aarch64.tar.gz
           path: dist/coveralls-linux-aarch64.tar.gz
@@ -152,7 +152,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -160,7 +160,7 @@ jobs:
         run: git fetch --force --tags
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 
@@ -200,7 +200,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
+        uses: dawidd6/action-homebrew-bump-formula@v4
         with:
           tap: coverallsapp/coveralls
           formula: coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
           mkdir release/
           find artifacts/ -type f -exec cp \{} release/ \;
           cd release/
+          mv coveralls.exe coveralls-windows.exe
           sha256sum * > coveralls-checksums.txt
 
       - name: Create GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,26 +69,53 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: 1.13.1
+      - name: Set up Docker BuildX
+        run: |
+          docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+          docker buildx create --use
 
-      - name: Build (Linux)
-        run: make release_linux
+      - name: Build multi-architecture binaries
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg CRYSTAL_VERSION=1.13.1 \
+            --output type=local,dest=dist/ \
+            -t coveralls/coverage-reporter .
 
-      - name: Upload binary
+      - name: Rename and prepare artifacts
+        run: |
+          cd dist
+          mv coveralls-linux-amd64 coveralls-x86_64
+          mv coveralls-linux-arm64 coveralls-aarch64
+          tar -czf coveralls-x86_64.tar.gz coveralls-x86_64
+          tar -czf coveralls-aarch64.tar.gz coveralls-aarch64
+          
+      - name: Upload binaries and archives
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-linux
-          path: dist/coveralls
+          name: coveralls-x86_64
+          path: dist/coveralls-x86_64
           if-no-files-found: error
 
-      - name: Upload tar.gz
+      - name: Upload tar.gz archives
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-linux.tar.gz
-          path: dist/coveralls-linux.tar.gz
+          name: coveralls-x86_64.tar.gz
+          path: dist/coveralls-x86_64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload ARM binaries and archives
+        uses: actions/upload-artifact@v3
+        with:
+          name: coveralls-aarch64
+          path: dist/coveralls-aarch64
+          if-no-files-found: error
+
+      - name: Upload ARM tar.gz archives
+        uses: actions/upload-artifact@v3
+        with:
+          name: coveralls-aarch64.tar.gz
+          path: dist/coveralls-aarch64.tar.gz
           if-no-files-found: error
 
   release:
@@ -113,7 +140,8 @@ jobs:
           mkdir release/
           find artifacts/ -type f -exec cp \{} release/ \;
           cd release/
-          mv coveralls coveralls-linux
+          mv coveralls-x86_64 coveralls-linux-x86_64
+          mv coveralls-aarch64 coveralls-linux-aarch64
           mv coveralls.exe coveralls-windows.exe
           sha256sum * > coveralls-checksums.txt
 
@@ -124,8 +152,10 @@ jobs:
         run: >
           cd release/;
           gh release create ${TAG}
-          'coveralls-linux#coveralls-linux'
-          'coveralls-linux.tar.gz#coveralls-linux.tar.gz'
+          'coveralls-linux-x86_64#coveralls-linux-x86_64'
+          'coveralls-linux-x86_64.tar.gz#coveralls-linux-x86_64.tar.gz'
+          'coveralls-linux-aarch64#coveralls-linux-aarch64'
+          'coveralls-linux-aarch64.tar.gz#coveralls-linux-aarch64.tar.gz'
           'coveralls-windows.exe#coveralls-windows.exe'
           'coveralls-windows.zip#coveralls-windows.zip'
           'coveralls-checksums.txt#coveralls-checksums.txt'
@@ -142,4 +172,3 @@ jobs:
           tap: coverallsapp/coveralls
           formula: coveralls
           token: ${{ secrets.HOMEBREW_TOKEN }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Rename and prepare artifacts
         run: |
           cd dist
-          mv linux/amd64/coveralls coveralls-x86_64
-          mv linux/arm64/coveralls coveralls-aarch64
+          mv linux_amd64/app/coveralls coveralls-x86_64
+          mv linux_arm64/app/coveralls coveralls-aarch64
           tar -czf coveralls-x86_64.tar.gz coveralls-x86_64
           tar -czf coveralls-aarch64.tar.gz coveralls-aarch64
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-2xlarge
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,33 +76,32 @@ jobs:
           docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
           docker buildx create --use
 
-      - name: Build multi-architecture binaries
+      - name: Build x86_64 binary
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64 \
             --build-arg CRYSTAL_VERSION=1.13.1 \
-            --output type=local,dest=dist/ .
+            --target x86_64_binary \
+            --output type=local,dest=./dist .
 
-      - name: (Debug) Inspect dist directory contents
+      - name: Build aarch64 binary
         run: |
-          echo "Listing contents of dist directory:"
-          ls -R dist
-
-      - name: (Debug) Search for coveralls binary in dist directory
-        run: |
-          echo "Searching for coveralls binary in dist directory:"
-          find dist -type f -name 'coveralls' -exec ls -l {} \;
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg CRYSTAL_VERSION=1.13.1 \
+            --target aarch64_binary \
+            --output type=local,dest=./dist .
 
       - name: Rename and prepare artifacts
         run: |
           cd dist
-          mv linux_amd64/app/coveralls-linux-x86_64 coveralls-linux-x86_64
-          mv linux_arm64/app/coveralls-linux-aarch64 coveralls-linux-aarch64
-          cp coveralls-linux-x86_64 coveralls-linux # Create the "generic" linux binary for backwards compatibility with github-action and orb
+          cp coveralls-linux-x86_64 coveralls-linux  # Create the "generic" linux binary for backward compatibility
+          mv coveralls-linux-x86_64 coveralls-linux-x86_64  # Retain the architecture-specific name
+          mv coveralls-linux-aarch64 coveralls-linux-aarch64
           tar -czf coveralls-linux.tar.gz coveralls-linux
           tar -czf coveralls-linux-x86_64.tar.gz coveralls-linux-x86_64
           tar -czf coveralls-linux-aarch64.tar.gz coveralls-linux-aarch64
-          
+
       - name: Upload generic linux binary (x86_64)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,8 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --build-arg CRYSTAL_VERSION=1.13.1 \
             --output type=local,dest=dist/ \
-            -t coveralls/coverage-reporter .
+            --target builder .
 
       - name: (Debug) Inspect dist directory contents
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,12 +92,17 @@ jobs:
             --target aarch64_binary \
             --output type=local,dest=./dist .
 
+      - name: (Debug) Check contents of dist directory
+        run: |
+          echo "Contents of dist directory:"
+          ls -lh ./dist/
+          echo "Detailed contents of dist directory:"
+          find ./dist/ -type f -exec ls -lh {} \;
+
       - name: Rename and prepare artifacts
         run: |
           cd dist
           cp coveralls-linux-x86_64 coveralls-linux  # Create the "generic" linux binary for backward compatibility
-          mv coveralls-linux-x86_64 coveralls-linux-x86_64  # Retain the architecture-specific name
-          mv coveralls-linux-aarch64 coveralls-linux-aarch64
           tar -czf coveralls-linux.tar.gz coveralls-linux
           tar -czf coveralls-linux-x86_64.tar.gz coveralls-linux-x86_64
           tar -czf coveralls-linux-aarch64.tar.gz coveralls-linux-aarch64
@@ -168,10 +173,6 @@ jobs:
           mkdir release/
           find artifacts/ -type f -exec cp \{} release/ \;
           cd release/
-          mv coveralls-linux coveralls-linux  # Include the generic linux binary for backwards compatibility with github-action and orb
-          mv coveralls-linux-x86_64 coveralls-linux-x86_64
-          mv coveralls-linux-aarch64 coveralls-linux-aarch64
-          mv coveralls-windows.exe coveralls-windows.exe
           sha256sum * > coveralls-checksums.txt
 
       - name: Create GitHub release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --output type=local,dest=dist/ \
-            --target builder .
+            --build-arg CRYSTAL_VERSION=1.13.1 \
+            --output type=local,dest=dist/ .
 
       - name: (Debug) Inspect dist directory contents
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Rename and prepare artifacts
         run: |
           cd dist
-          mv coveralls-linux-amd64 coveralls-x86_64
-          mv coveralls-linux-arm64 coveralls-aarch64
+          mv linux/amd64/coveralls coveralls-x86_64
+          mv linux/arm64/coveralls coveralls-aarch64
           tar -czf coveralls-x86_64.tar.gz coveralls-x86_64
           tar -czf coveralls-aarch64.tar.gz coveralls-aarch64
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-22.04-2xlarge
+    runs-on: ubuntu-latest-m
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,11 @@ jobs:
           echo "Listing contents of dist directory:"
           ls -R dist
 
+      - name: (Debug) Search for coveralls binary in dist directory
+        run: |
+          echo "Searching for coveralls binary in dist directory:"
+          find dist -type f -name 'coveralls' -exec ls -l {} \;
+
       - name: Rename and prepare artifacts
         run: |
           cd dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
 
 jobs:
+  # Build the Windows binary
   build-windows:
     runs-on: windows-2022
     steps:
@@ -63,6 +64,7 @@ jobs:
           path: dist/coveralls-windows.zip
           if-no-files-found: error
 
+  # Build the Linux binaries for multiple architectures
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -94,39 +96,56 @@ jobs:
       - name: Rename and prepare artifacts
         run: |
           cd dist
-          mv linux_amd64/app/coveralls coveralls-x86_64
-          mv linux_arm64/app/coveralls coveralls-aarch64
-          tar -czf coveralls-x86_64.tar.gz coveralls-x86_64
-          tar -czf coveralls-aarch64.tar.gz coveralls-aarch64
+          mv linux_amd64/app/coveralls-linux-x86_64 coveralls-linux-x86_64
+          mv linux_arm64/app/coveralls-linux-aarch64 coveralls-linux-aarch64
+          cp coveralls-linux-x86_64 coveralls-linux # Create the "generic" linux binary for backwards compatibility with github-action and orb
+          tar -czf coveralls-linux.tar.gz coveralls-linux
+          tar -czf coveralls-linux-x86_64.tar.gz coveralls-linux-x86_64
+          tar -czf coveralls-linux-aarch64.tar.gz coveralls-linux-aarch64
           
-      - name: Upload binaries and archives
+      - name: Upload generic linux binary (x86_64)
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-x86_64
-          path: dist/coveralls-x86_64
+          name: coveralls-linux
+          path: dist/coveralls-linux
           if-no-files-found: error
 
-      - name: Upload tar.gz archives
+      - name: Upload generic linux (x86_64) tar.gz archive
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-x86_64.tar.gz
-          path: dist/coveralls-x86_64.tar.gz
+          name: coveralls-linux.tar.gz
+          path: dist/coveralls-linux.tar.gz
           if-no-files-found: error
 
-      - name: Upload ARM binaries and archives
+      - name: Upload x86_64-specific binary
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-aarch64
-          path: dist/coveralls-aarch64
+          name: coveralls-linux-x86_64
+          path: dist/coveralls-linux-x86_64
           if-no-files-found: error
 
-      - name: Upload ARM tar.gz archives
+      - name: Upload x86_64-specific tar.gz archive
         uses: actions/upload-artifact@v3
         with:
-          name: coveralls-aarch64.tar.gz
-          path: dist/coveralls-aarch64.tar.gz
+          name: coveralls-linux-x86_64.tar.gz
+          path: dist/coveralls-linux-x86_64.tar.gz
           if-no-files-found: error
 
+      - name: Upload aarch64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: coveralls-linux-aarch64
+          path: dist/coveralls-linux-aarch64
+          if-no-files-found: error
+
+      - name: Upload aarch64 tar.gz archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: coveralls-linux-aarch64.tar.gz
+          path: dist/coveralls-linux-aarch64.tar.gz
+          if-no-files-found: error
+
+  # Create a GitHub release and attach built artifacts
   release:
     runs-on: ubuntu-latest
     needs: [build-windows, build-linux]
@@ -140,7 +159,8 @@ jobs:
       - name: Fetch tags
         run: git fetch --force --tags
 
-      - uses: actions/download-artifact@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
           path: artifacts/
 
@@ -149,18 +169,21 @@ jobs:
           mkdir release/
           find artifacts/ -type f -exec cp \{} release/ \;
           cd release/
-          mv coveralls-x86_64 coveralls-linux-x86_64
-          mv coveralls-aarch64 coveralls-linux-aarch64
-          mv coveralls.exe coveralls-windows.exe
+          mv coveralls-linux coveralls-linux  # Include the generic linux binary for backwards compatibility with github-action and orb
+          mv coveralls-linux-x86_64 coveralls-linux-x86_64
+          mv coveralls-linux-aarch64 coveralls-linux-aarch64
+          mv coveralls-windows.exe coveralls-windows.exe
           sha256sum * > coveralls-checksums.txt
 
-      - name: Create Github release
+      - name: Create GitHub release
         env:
           TAG: ${{ github.ref }}
           GH_TOKEN: ${{ github.token }}
         run: >
           cd release/;
           gh release create ${TAG}
+          'coveralls-linux#coveralls-linux'  # Upload generic linux binary for backawrds compatibility with github-action and orb
+          'coveralls-linux.tar.gz#coveralls-linux.tar.gz'  # Upload generic linux tar.gz archive for backwards compatibility with github-action and orb
           'coveralls-linux-x86_64#coveralls-linux-x86_64'
           'coveralls-linux-x86_64.tar.gz#coveralls-linux-x86_64.tar.gz'
           'coveralls-linux-aarch64#coveralls-linux-aarch64'
@@ -170,6 +193,7 @@ jobs:
           'coveralls-checksums.txt#coveralls-checksums.txt'
           --generate-notes
 
+  # Update the Homebrew formula for MacOS releases
   homebrew:
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,11 @@ jobs:
             --output type=local,dest=dist/ \
             -t coveralls/coverage-reporter .
 
+      - name: (Debug) Inspect dist directory contents
+        run: |
+          echo "Listing contents of dist directory:"
+          ls -R dist
+
       - name: Rename and prepare artifacts
         run: |
           cd dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-22.04-medium
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest-xl
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   # Build the Linux binaries for multiple architectures
   build-linux:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:latest AS builder-x86_64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache libyaml musl-dev
+RUN apk add --no-cache yaml musl-dev
 
 # Copy the source code
 COPY . .
@@ -20,7 +20,7 @@ FROM 84codes/crystal:latest AS builder-aarch64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache libyaml
+RUN apk add --no-cache yaml
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-x86_64
 # Set the working directory
 WORKDIR /app
 
-# Install required packages
-RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev build-essential
+# Update and upgrade system packages, then install required packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y libyaml-dev liblzma-dev build-essential
 
 # Copy the source code
 COPY . .
@@ -19,8 +19,8 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
 # Set the working directory
 WORKDIR /app
 
-# Install required packages
-RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
+# Update and upgrade system packages, then install required packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,12 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
 # Set the working directory
 WORKDIR /app
 
+# Check disk space usage
+RUN df -h
+
 # Update and upgrade system packages, then install required packages (separate lines for less memory use)
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,15 @@ WORKDIR /app
 # Check disk space usage
 RUN df -h
 
-# Update the package list
+# Try this solution to segfault error installing libc-bin
+# From: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
+RUN rm /var/lib/dpkg/info/libc-bin.*
+RUN apt-get clean
 RUN apt-get update
+RUN apt-get install libc-bin
+
+## Update the package list (hold for above solution)
+#RUN apt-get update
 
 # Install libc-bin separately to reduce memory usage during installation
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,5 @@
-# Stage 1: Install Crystal and Build x86_64 Binary
-FROM debian:buster AS builder-x86_64
-
-# Install dependencies and Crystal
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    libssl-dev \
-    libxml2-dev \
-    libyaml-dev \
-    libgmp-dev \
-    curl \
-    git \
-    gcc \
-    g++ \
-    make \
-    musl-tools \
-    wget \
-    gnupg2 \
-    apt-transport-https \
-    ca-certificates \
-    && curl -fsSL https://keybase.io/crystal/pgp_keys.asc | apt-key add - \
-    && echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list \
-    && apt-get update \
-    && apt-get install -y crystal
+# Stage 1: Build x86_64 Binary
+FROM 84codes/crystal:latest AS builder-x86_64
 
 # Set the working directory
 WORKDIR /app
@@ -29,33 +7,11 @@ WORKDIR /app
 # Copy the source code
 COPY . .
 
-# Install shards dependencies and build the x86_64 binary
-RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls-x86_64
+# Install dependencies and build the x86_64 binary
+RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls-linux-x86_64
 
-# Stage 2: Install Crystal and Build aarch64 Binary
-FROM debian:buster AS builder-aarch64
-
-# Install dependencies and Crystal
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    libssl-dev \
-    libxml2-dev \
-    libyaml-dev \
-    libgmp-dev \
-    curl \
-    git \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu \
-    make \
-    musl-tools \
-    wget \
-    gnupg2 \
-    apt-transport-https \
-    ca-certificates \
-    && curl -fsSL https://keybase.io/crystal/pgp_keys.asc | apt-key add - \
-    && echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list \
-    && apt-get update \
-    && apt-get install -y crystal
+# Stage 2: Build aarch64 Binary
+FROM 84codes/crystal:latest AS builder-aarch64
 
 # Set the working directory
 WORKDIR /app
@@ -63,16 +19,19 @@ WORKDIR /app
 # Copy the source code
 COPY . .
 
-# Install shards dependencies and build the aarch64 binary
-RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-aarch64
+# Install dependencies and build the aarch64 binary
+RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-linux-aarch64
 
 # Stage 3: Final Image with the Binaries
 FROM debian:buster-slim
 WORKDIR /app
 
 # Copy the binaries from the builder stages
-COPY --from=builder-x86_64 /app/coveralls-x86_64 /app/coveralls-x86_64
-COPY --from=builder-aarch64 /app/coveralls-aarch64 /app/coveralls-aarch64
+COPY --from=builder-x86_64 /app/coveralls-linux-x86_64 /app/coveralls-linux-x86_64
+COPY --from=builder-aarch64 /app/coveralls-linux-aarch64 /app/coveralls-linux-aarch64
+
+# Create a generic linux binary named coveralls-linux
+RUN cp /app/coveralls-linux-x86_64 /app/coveralls-linux
 
 # Optionally, set entry point if needed
-# ENTRYPOINT ["/app/coveralls-x86_64"]
+# ENTRYPOINT ["/app/coveralls-linux"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 COPY --from=builder-x86_64 /app /app
 RUN sed -i '/ameba/d' shard.yml \
     && sed -i '/crystal-kcov/d' shard.yml \
+    && rm -rf lib/ameba lib/crystal-kcov \
     && shards install --ignore-crystal-version \
     && mkdir -p /app/bin \
     && crystal build --release src/coverage_reporter.cr -o /app/bin/coveralls-linux-aarch64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
 # Stage 1: Build x86_64 Binary
-FROM 84codes/crystal:latest AS builder-x86_64
+FROM 84codes/crystal:master-ubuntu-22.04 as builder-x86_64
 
 # Set the working directory
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache yaml musl-dev
+RUN apt-get update && apt-get install -y libyaml-dev build-essential
 
 # Copy the source code
 COPY . .
 
 # Install dependencies and build the x86_64 binary
-RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls-linux-x86_64
+RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-gnu -o /app/coveralls-linux-x86_64
 
 # Stage 2: Build aarch64 Binary
-FROM 84codes/crystal:latest AS builder-aarch64
+FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
 
 # Set the working directory
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache yaml
+RUN apt-get update && apt-get install -y libyaml-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code
 COPY . .
@@ -29,7 +29,7 @@ COPY . .
 RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-linux-aarch64
 
 # Stage 3: Final Image with the Binaries
-FROM debian:buster-slim
+FROM ubuntu:22.04
 WORKDIR /app
 
 # Copy the binaries from the builder stages

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,28 @@ RUN df -h
 
 # Try this solution to segfault error installing libc-bin
 # From: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
-RUN rm /var/lib/dpkg/info/libc-bin.*
-RUN apt-get clean
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
+#RUN rm /var/lib/dpkg/info/libc-bin.*
+#RUN apt-get clean
+#RUN apt-get update
+#RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
+
+# Try this solution to segfault error installing libc-bin
+# From: https://www.grepper.com/answers/426226/installed+libc-bin+package+post-installation+script+subprocess+returned+error+exit+status+134
+# Update and install necessary packages
+RUN apt-get update && apt-get install -y curl gnupg
+# Handle libc-bin package separately to fix segmentation fault issues
+# Move the libc-bin metadata files out of the way
+RUN mv /var/lib/dpkg/info/libc-bin.* /tmp/
+# Forcefully remove the libc-bin package
+RUN dpkg --remove --force-remove-reinstreq libc-bin
+# Purge the libc-bin package completely
+RUN dpkg --purge libc-bin
+# Clean up and update the package list
+RUN apt-get clean && apt-get update
+# Reinstall the libc-bin package
+RUN apt-get install -y libc-bin
+# Move the libc-bin metadata files back to their original location
+RUN mv /tmp/libc-bin.* /var/lib/dpkg/info/
 
 # Install the remaining packages
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-x86_64
 WORKDIR /app
 
 # Install required packages
-RUN apt-get update && apt-get install -y libyaml-dev build-essential
+RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev build-essential
 
 # Copy the source code
 COPY . .
@@ -20,7 +20,7 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
 WORKDIR /app
 
 # Install required packages
-RUN apt-get update && apt-get install -y libyaml-dev gcc-aarch64-linux-gnu build-essential
+RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
 # Set the working directory
 WORKDIR /app
 
-# Update and upgrade system packages, then install required packages
-RUN apt-get update && apt-get upgrade -y && apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
+# Update and upgrade system packages, then install required packages (separate lines for less memory use)
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:latest AS builder-x86_64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache libyaml-dev musl-dev
+RUN apk add --no-cache yaml-dev musl-dev
 
 # Copy the source code
 COPY . .
@@ -20,7 +20,7 @@ FROM 84codes/crystal:latest AS builder-aarch64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache libyaml-dev
+RUN apk add --no-cache yaml-dev
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM 84codes/crystal:latest AS builder-x86_64
 # Set the working directory
 WORKDIR /app
 
+# Install required packages
+RUN apk add --no-cache libyaml-dev
+
 # Copy the source code
 COPY . .
 
@@ -15,6 +18,9 @@ FROM 84codes/crystal:latest AS builder-aarch64
 
 # Set the working directory
 WORKDIR /app
+
+# Install required packages
+RUN apk add --no-cache libyaml-dev
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Install Crystal and Build x86_64 Binary
 FROM debian:buster AS builder-x86_64
 
-# Install dependencies
+# Install dependencies and Crystal
 RUN apt-get update && apt-get install -y \
     build-essential \
     libssl-dev \
@@ -14,14 +14,14 @@ RUN apt-get update && apt-get install -y \
     g++ \
     make \
     musl-tools \
-    wget
-
-# Install Crystal
-RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.tar.gz \
-    && tar -xzf crystal-1.13.1-1-linux-x86_64.tar.gz \
-    && mv crystal-1.13.1-1 /usr/local/crystal \
-    && ln -s /usr/local/crystal/bin/crystal /usr/local/bin/crystal \
-    && apt-get install -f
+    wget \
+    gnupg2 \
+    apt-transport-https \
+    ca-certificates \
+    && curl -fsSL https://keybase.io/crystal/pgp_keys.asc | apt-key add - \
+    && echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list \
+    && apt-get update \
+    && apt-get install -y crystal
 
 # Set the working directory
 WORKDIR /app
@@ -35,7 +35,7 @@ RUN shards install && crystal build src/cli.cr --release --static --target x86_6
 # Stage 2: Install Crystal and Build aarch64 Binary
 FROM debian:buster AS builder-aarch64
 
-# Install dependencies
+# Install dependencies and Crystal
 RUN apt-get update && apt-get install -y \
     build-essential \
     libssl-dev \
@@ -48,14 +48,14 @@ RUN apt-get update && apt-get install -y \
     g++-aarch64-linux-gnu \
     make \
     musl-tools \
-    wget
-
-# Install Crystal (manually)
-RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.tar.gz \
-    && tar -xzf crystal-1.13.1-1-linux-x86_64.tar.gz \
-    && mv crystal-1.13.1-1 /usr/local/crystal \
-    && ln -s /usr/local/crystal/bin/crystal /usr/local/bin/crystal \
-    && apt-get install -f
+    wget \
+    gnupg2 \
+    apt-transport-https \
+    ca-certificates \
+    && curl -fsSL https://keybase.io/crystal/pgp_keys.asc | apt-key add - \
+    && echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list \
+    && apt-get update \
+    && apt-get install -y crystal
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ COPY --from=builder-x86_64 /app /app
 RUN sed -i '/ameba/d' shard.yml \
     && sed -i '/crystal-kcov/d' shard.yml \
     && rm -rf lib/* \
+    && rm -rf .shards
 
-# Reinstall dependencies form scratch without problematic ones and build the binary
+# (Debug) Add a step to verify the content of shard.yml after modification
+RUN cat shard.yml
+
+# Reinstall dependencies from scratch without problematic ones and build the binary
 RUN shards install --ignore-crystal-version \
     && mkdir -p /app/bin \
     && crystal build --release src/coverage_reporter.cr -o /app/bin/coveralls-linux-aarch64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,74 @@
-# Stage 1: Build x86_64 binary
-FROM crystallang/crystal:1.13.1-buster AS builder-x86_64
+# Stage 1: Install Crystal and Build x86_64 Binary
+FROM debian:buster AS builder-x86_64
 
-# Install necessary build tools and dependencies
+# Install dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
+    libssl-dev \
+    libxml2-dev \
+    libyaml-dev \
+    libgmp-dev \
+    curl \
+    git \
+    gcc \
+    g++ \
+    make \
     musl-tools \
-    && apt-get clean
+    wget
 
-# Copy source code into the container
+# Install Crystal
+RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.deb \
+    && dpkg -i crystal-1.13.1-1-linux-x86_64.deb \
+    && apt-get install -f
+
+# Set the working directory
 WORKDIR /app
+
+# Copy the source code
 COPY . .
 
-# Install dependencies and build the x86_64 binary
+# Install shards dependencies and build the x86_64 binary
 RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls-x86_64
 
-# Stage 2: Build aarch64 binary
-FROM crystallang/crystal:1.13.1-buster AS builder-aarch64
+# Stage 2: Install Crystal and Build aarch64 Binary
+FROM debian:buster AS builder-aarch64
 
-# Install necessary build tools and dependencies
+# Install dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
-    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools \
-    && apt-get clean
+    libssl-dev \
+    libxml2-dev \
+    libyaml-dev \
+    libgmp-dev \
+    curl \
+    git \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    make \
+    musl-tools \
+    wget
 
-# Copy source code into the container
+# Install Crystal (manually)
+RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.deb \
+    && dpkg -i crystal-1.13.1-1-linux-x86_64.deb \
+    && apt-get install -f
+
+# Set the working directory
 WORKDIR /app
+
+# Copy the source code
 COPY . .
 
-# Install dependencies and build the aarch64 binary
+# Install shards dependencies and build the aarch64 binary
 RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-aarch64
 
-# Stage 3: Final image with just the binaries
+# Stage 3: Final Image with the Binaries
 FROM debian:buster-slim
 WORKDIR /app
 
-# Copy both binaries from the builder stages
+# Copy the binaries from the builder stages
 COPY --from=builder-x86_64 /app/coveralls-x86_64 /app/coveralls-x86_64
 COPY --from=builder-aarch64 /app/coveralls-aarch64 /app/coveralls-aarch64
 
-# Optionally, set entry point if only one binary is needed to be run by default
+# Optionally, set entry point if needed
 # ENTRYPOINT ["/app/coveralls-x86_64"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,77 +1,33 @@
-# Stage 1: Build x86_64 Binary
-FROM 84codes/crystal:master-ubuntu-22.04 as builder-x86_64
+# ARG to specify Crystal version and base image tag
+ARG CRYSTAL_VERSION=1.13.1
+ARG BASE_IMAGE_TAG=ubuntu-22.04
 
-# Set the working directory
+# Stage 1: Build for x86_64
+FROM 84codes/crystal:${CRYSTAL_VERSION}-${BASE_IMAGE_TAG} AS builder-x86_64
 WORKDIR /app
+RUN git clone https://github.com/coverallsapp/coverage-reporter.git .
+RUN shards install --ignore-crystal-version \
+    && mkdir -p /app/bin \
+    && crystal build --release src/coverage_reporter.cr -o /app/bin/coveralls-linux-x86_64
 
-# Update and upgrade system packages, then install required packages
-RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev build-essential
-
-# Copy the source code
-COPY . .
-
-# Install dependencies and build the x86_64 binary
-RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-gnu -o /app/coveralls-linux-x86_64
-
-# Stage 2: Build aarch64 Binary
-FROM 84codes/crystal:master-ubuntu-22.04 as builder-aarch64
-
-# Set the working directory
+# Stage 2: Build for aarch64
+FROM 84codes/crystal:${CRYSTAL_VERSION}-${BASE_IMAGE_TAG} AS builder-aarch64
 WORKDIR /app
+COPY --from=builder-x86_64 /app /app
+RUN sed -i '/ameba/d' shard.yml \
+    && sed -i '/crystal-kcov/d' shard.yml \
+    && shards install --ignore-crystal-version \
+    && mkdir -p /app/bin \
+    && crystal build --release src/coverage_reporter.cr -o /app/bin/coveralls-linux-aarch64
 
-# Check disk space usage
-RUN df -h
+# Stage 3a: Export Binary for x86_64
+FROM scratch AS x86_64_binary
+COPY --from=builder-x86_64 /app/bin/coveralls-linux-x86_64 /
 
-## Update the package list (hold for solution below)
-#RUN apt-get update
+# Stage 3b: Export Binary for aarch64
+FROM scratch AS aarch64_binary
+COPY --from=builder-aarch64 /app/bin/coveralls-linux-aarch64 /
 
-## Install libc-bin separately to reduce memory usage during installation (hold for solution below)
-#RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
-
-# Try this solution to segfault error installing libc-bin
-# From: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
-#RUN rm /var/lib/dpkg/info/libc-bin.*
-#RUN apt-get clean
-#RUN apt-get update
-#RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
-
-# Try this solution to segfault error installing libc-bin
-# From: https://www.grepper.com/answers/426226/installed+libc-bin+package+post-installation+script+subprocess+returned+error+exit+status+134
-# Update and install necessary packages
-RUN apt-get update && apt-get install -y curl gnupg
-# Handle libc-bin package separately to fix segmentation fault issues
-# Move the libc-bin metadata files out of the way
-RUN mv /var/lib/dpkg/info/libc-bin.* /tmp/
-# Forcefully remove the libc-bin package
-RUN dpkg --remove --force-remove-reinstreq libc-bin
-# Purge the libc-bin package completely
-RUN dpkg --purge libc-bin
-# Clean up and update the package list
-RUN apt-get clean && apt-get update
-# Reinstall the libc-bin package
-RUN apt-get install -y libc-bin
-# Move the libc-bin metadata files back to their original location
-RUN mv /tmp/libc-bin.* /var/lib/dpkg/info/
-
-# Install the remaining packages
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
-
-# Copy the source code
-COPY . .
-
-# Install dependencies and build the aarch64 binary
-RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-linux-aarch64
-
-# Stage 3: Final Image with the Binaries
-FROM ubuntu:22.04
-WORKDIR /app
-
-# Copy the binaries from the builder stages
-COPY --from=builder-x86_64 /app/coveralls-linux-x86_64 /app/coveralls-linux-x86_64
-COPY --from=builder-aarch64 /app/coveralls-linux-aarch64 /app/coveralls-linux-aarch64
-
-# Create a generic linux binary named coveralls-linux
-RUN cp /app/coveralls-linux-x86_64 /app/coveralls-linux
-
-# Optionally, set entry point if needed
-# ENTRYPOINT ["/app/coveralls-linux"]
+# Stage 4: Final stage to create a generic binary for backward compatibility
+FROM scratch AS final
+COPY --from=x86_64_binary /coveralls-linux-x86_64 /coveralls-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN shards install --ignore-crystal-version \
 FROM 84codes/crystal:${CRYSTAL_VERSION}-${BASE_IMAGE_TAG} AS builder-aarch64
 WORKDIR /app
 COPY --from=builder-x86_64 /app /app
+
+# Remove problematic dependencies for aarch64 and clean the lib directory
 RUN sed -i '/ameba/d' shard.yml \
     && sed -i '/crystal-kcov/d' shard.yml \
-    && rm -rf lib/ameba lib/crystal-kcov \
-    && shards install --ignore-crystal-version \
+    && rm -rf lib/* \
+
+# Reinstall dependencies form scratch without problematic ones and build the binary
+RUN shards install --ignore-crystal-version \
     && mkdir -p /app/bin \
     && crystal build --release src/coverage_reporter.cr -o /app/bin/coveralls-linux-aarch64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,17 @@ WORKDIR /app
 # Check disk space usage
 RUN df -h
 
+## Update the package list (hold for solution below)
+#RUN apt-get update
+
+## Install libc-bin separately to reduce memory usage during installation (hold for solution below)
+#RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
+
 # Try this solution to segfault error installing libc-bin
 # From: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
 RUN rm /var/lib/dpkg/info/libc-bin.*
 RUN apt-get clean
 RUN apt-get update
-RUN apt-get install libc-bin
-
-## Update the package list (hold for above solution)
-#RUN apt-get update
-
-# Install libc-bin separately to reduce memory usage during installation
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
 
 # Install the remaining packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-ARG CRYSTAL_VERSION
-FROM crystallang/crystal:${CRYSTAL_VERSION}-buster
+# Use a Debian-based image
+FROM debian:buster-slim
 
-# Install necessary dependencies for both x86_64 and aarch64
+# Install necessary dependencies and Crystal
+ARG CRYSTAL_VERSION=1.13.1
 RUN apt-get update && apt-get install -y \
+    curl \
     xz-utils libxml2-dev sqlite3 libsqlite3-dev \
     gcc g++ \
     gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools \
-    && apt-get clean
+    && curl -L https://github.com/crystal-lang/crystal/releases/download/${CRYSTAL_VERSION}/crystal-${CRYSTAL_VERSION}-1-linux-x86_64.tar.gz | tar -xz -C /usr/local \
+    && ln -s /usr/local/crystal-${CRYSTAL_VERSION}-1/bin/crystal /usr/local/bin/crystal \
+    && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,42 @@
-# Stage 1: Build the binary
-FROM crystallang/crystal:1.13.1-alpine AS builder
+# Stage 1: Build x86_64 binary
+FROM crystallang/crystal:1.13.1-buster AS builder-x86_64
 
 # Install necessary build tools and dependencies
-RUN apk add --no-cache build-base
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    musl-tools \
+    && apt-get clean
 
 # Copy source code into the container
 WORKDIR /app
 COPY . .
 
-# Install dependencies and build the binary
-RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls
+# Install dependencies and build the x86_64 binary
+RUN shards install && crystal build src/cli.cr --release --static --target x86_64-linux-musl -o /app/coveralls-x86_64
 
-# Stage 2: Final image with just the binary
-FROM alpine:latest
+# Stage 2: Build aarch64 binary
+FROM crystallang/crystal:1.13.1-buster AS builder-aarch64
+
+# Install necessary build tools and dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools \
+    && apt-get clean
+
+# Copy source code into the container
 WORKDIR /app
-COPY --from=builder /app/coveralls /app/coveralls
+COPY . .
 
-# Run the binary
-ENTRYPOINT ["/app/coveralls"]
+# Install dependencies and build the aarch64 binary
+RUN shards install && crystal build src/cli.cr --release --static --cross-compile --target aarch64-linux-gnu -o /app/coveralls-aarch64
+
+# Stage 3: Final image with just the binaries
+FROM debian:buster-slim
+WORKDIR /app
+
+# Copy both binaries from the builder stages
+COPY --from=builder-x86_64 /app/coveralls-x86_64 /app/coveralls-x86_64
+COPY --from=builder-aarch64 /app/coveralls-aarch64 /app/coveralls-aarch64
+
+# Optionally, set entry point if only one binary is needed to be run by default
+# ENTRYPOINT ["/app/coveralls-x86_64"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,13 @@ WORKDIR /app
 # Check disk space usage
 RUN df -h
 
-# Update and upgrade system packages, then install required packages (separate lines for less memory use)
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y
+# Update the package list
+RUN apt-get update
+
+# Install libc-bin separately to reduce memory usage during installation
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libc-bin
+
+# Install the remaining packages
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libyaml-dev liblzma-dev gcc-aarch64-linux-gnu build-essential
 
 # Copy the source code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 ARG CRYSTAL_VERSION
-FROM crystallang/crystal:${CRYSTAL_VERSION}-alpine
+FROM crystallang/crystal:${CRYSTAL_VERSION}-buster
 
 # Install necessary dependencies for both x86_64 and aarch64
-RUN apk add --no-cache xz-dev xz-static libxml2-dev libxml2-static sqlite-dev sqlite-static \
-    && apk add --no-cache --virtual .build-deps gcc musl-dev g++ \
-    && apk add --no-cache --virtual .cross-deps gcc-aarch64-linux-gnu musl-dev-aarch64
+RUN apt-get update && apt-get install -y \
+    xz-utils libxml2-dev sqlite3 libsqlite3-dev \
+    gcc g++ \
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools \
+    && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && apt-get install -y \
     wget
 
 # Install Crystal
-RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.deb \
-    && dpkg -i crystal-1.13.1-1-linux-x86_64.deb \
+RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.tar.gz \
+    && tar -xzf crystal-1.13.1-1-linux-x86_64.tar.gz \
+    && mv crystal-1.13.1-1 /usr/local/crystal \
+    && ln -s /usr/local/crystal/bin/crystal /usr/local/bin/crystal \
     && apt-get install -f
 
 # Set the working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:latest AS builder-x86_64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache libyaml-dev
+RUN apk add --no-cache libyaml-dev musl-dev
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,10 @@ RUN apt-get update && apt-get install -y \
     wget
 
 # Install Crystal (manually)
-RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.deb \
-    && dpkg -i crystal-1.13.1-1-linux-x86_64.deb \
+RUN wget https://github.com/crystal-lang/crystal/releases/download/1.13.1/crystal-1.13.1-1-linux-x86_64.tar.gz \
+    && tar -xzf crystal-1.13.1-1-linux-x86_64.tar.gz \
+    && mv crystal-1.13.1-1 /usr/local/crystal \
+    && ln -s /usr/local/crystal/bin/crystal /usr/local/bin/crystal \
     && apt-get install -f
 
 # Set the working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:latest AS builder-x86_64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache yaml-dev musl-dev
+RUN apk add --no-cache libyaml musl-dev
 
 # Copy the source code
 COPY . .
@@ -20,7 +20,7 @@ FROM 84codes/crystal:latest AS builder-aarch64
 WORKDIR /app
 
 # Install required packages
-RUN apk add --no-cache yaml-dev
+RUN apk add --no-cache libyaml
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 84codes/crystal:master-ubuntu-22.04 as builder-x86_64
 WORKDIR /app
 
 # Update and upgrade system packages, then install required packages
-RUN apt-get update && apt-get upgrade -y && apt-get install -y libyaml-dev liblzma-dev build-essential
+RUN apt-get update && apt-get install -y libyaml-dev liblzma-dev build-essential
 
 # Copy the source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 ARG CRYSTAL_VERSION
 FROM crystallang/crystal:${CRYSTAL_VERSION}-alpine
 
-RUN apk add xz-dev xz-static libxml2-dev libxml2-static sqlite-dev sqlite-static
+# Install necessary dependencies for both x86_64 and aarch64
+RUN apk add --no-cache xz-dev xz-static libxml2-dev libxml2-static sqlite-dev sqlite-static \
+    && apk add --no-cache --virtual .build-deps gcc musl-dev g++ \
+    && apk add --no-cache --virtual .cross-deps gcc-aarch64-linux-gnu musl-dev-aarch64


### PR DESCRIPTION
Closes #137 

#### :zap: Summary

Add `aarch64` support to `coverage-reporter`.

Update `build.yml` workflow to cross-compile linux binaries for `x86_64` and `aarch64`.

#### :ballot_box_with_check: Checklist

- [x] Modify `build.yml` workflow to compile and upload linux binaries for `x86_64` and `aarch64`
  - [x] New method utilizes `docker buildx`, removing the need for `release_linux` in the existing `Makefile`
  - [x] Modify existing `Dockerfile` to install additional dependencies required to build for `x86_64` and `aarch64` 
