### PR TITLE
Update golang parser regex

### DIFF
--- a/spec/coverage_reporter/parsers/golang_parser_spec.cr
+++ b/spec/coverage_reporter/parsers/golang_parser_spec.cr
@@ -7,6 +7,8 @@ Spectator.describe CoverageReporter::GolangParser do
     it "matches correct filenames" do
       expect(subject.matches?("spec/fixtures/golang/coverage.out")).to eq true
       expect(subject.matches?("spec/fixtures/golang/coverage-dashes.out")).to eq true
+      expect(subject.matches?("spec/fixtures/golang/coverage-two-slashes.out")).to eq true
+      expect(subject.matches?("spec/fixtures/golang/coverage-one-slash.out")).to eq true
       expect(subject.matches?("spec/fixtures/test.lcov")).to eq false
       expect(subject.matches?("some-non-existing-file.out")).to eq false
     end

--- a/spec/fixtures/golang/coverage-one-slash.out
+++ b/spec/fixtures/golang/coverage-one-slash.out
@@ -1,0 +1,2 @@
+mode: atomic
+mymodule/main.go:3.14,4.2 0 1

--- a/spec/fixtures/golang/coverage-two-slashes.out
+++ b/spec/fixtures/golang/coverage-two-slashes.out
@@ -1,0 +1,2 @@
+mode: atomic
+example.com/mypackge/main.go:47.20,58.2 1 1

--- a/src/coverage_reporter/parsers/golang_parser.cr
+++ b/src/coverage_reporter/parsers/golang_parser.cr
@@ -3,7 +3,7 @@ require "./base_parser"
 module CoverageReporter
   class GolangParser < BaseParser
     COVERAGE_RE = Regex.new(
-      "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+\\/(?:v\\d+\\/)?(.*\\.go):(\\d+)\\.\\d+,(\\d+)\\.\\d+\\s+\\d+\\s+(\\d+)",
+      "^[\\w.-]+\\/(?:[\\w.-]+\\/)?(?:[\\w.-]+\\/)?(?:v\\d+\\/)?(.*\\.go):(\\d+)\\.\\d+,(\\d+)\\.\\d+\\s+\\d+\\s+(\\d+)",
       Regex::CompileOptions::MATCH_INVALID_UTF # don't raise error agains non-UTF chars
     )
 


### PR DESCRIPTION
#### :zap: Summary

I updated go to go 1.22 and noticed that CI was failing to upload test coverage to coveralls. I discovered that coveralls was detecting the file type as `lcov` when it should have been `golang`. This was because the regex in the golang parser expected three slashes in the file path for each file under test.

I updated the regex to only have one slash be required, while ensuring that existing tests didn't fail. I added two new fixture files and added two new tests to ensure the new behavior works correctly.

#### :ballot_box_with_check: Checklist

- [X] Add specs
