### PR TITLE
Fix syntax on GitHub CLI call.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,16 +191,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >
           cd release/;
-          gh release create ${TAG} \
-          "coveralls-linux#coveralls-linux" \
-          "coveralls-linux.tar.gz#coveralls-linux.tar.gz" \
-          "coveralls-linux-x86_64#coveralls-linux-x86_64" \
-          "coveralls-linux-x86_64.tar.gz#coveralls-linux-x86_64.tar.gz" \
-          "coveralls-linux-aarch64#coveralls-linux-aarch64" \
-          "coveralls-linux-aarch64.tar.gz#coveralls-linux-aarch64.tar.gz" \
-          "coveralls-windows.exe#coveralls-windows.exe" \
-          "coveralls-windows.zip#coveralls-windows.zip" \
-          "coveralls-checksums.txt#coveralls-checksums.txt" \
+          gh release create ${TAG}
+          'coveralls-linux#coveralls-linux'
+          'coveralls-linux.tar.gz#coveralls-linux.tar.gz'
+          'coveralls-linux-x86_64#coveralls-linux-x86_64'
+          'coveralls-linux-x86_64.tar.gz#coveralls-linux-x86_64.tar.gz'
+          'coveralls-linux-aarch64#coveralls-linux-aarch64'
+          'coveralls-linux-aarch64.tar.gz#coveralls-linux-aarch64.tar.gz'
+          'coveralls-windows.exe#coveralls-windows.exe'
+          'coveralls-windows.zip#coveralls-windows.zi'p
+          'coveralls-checksums.txt#coveralls-checksums.txt'
           --generate-notes
 
   # Update the Homebrew formula for MacOS releases


### PR DESCRIPTION
#### :zap: Summary

Fix broken release workflow.

#### :ballot_box_with_check: Checklist

- [x] Fix syntax of GitHub CLI call in "Create GitHub release" step
