### PR TITLE
Fix cross-compilation issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,9 @@ jobs:
           # Ensure the directory exists
           if [ -d "dist/x86_64" ]; then
             # Create tarball for x86_64
-            tar -czf dist/coveralls-linux-x86_64.tar.gz -C dist/x86_64 coveralls
+            tar -cvzf dist/coveralls-linux-x86_64.tar.gz -C dist/x86_64 coveralls
             # Create generic tarball for backward compatibility
-            tar -czf dist/coveralls-linux.tar.gz -C dist/x86_64 coveralls
+            tar -cvzf dist/coveralls-linux.tar.gz -C dist/x86_64 coveralls
             # Create binaries for upload
             cp dist/x86_64/coveralls dist/coveralls-linux
             cp dist/x86_64/coveralls dist/coveralls-linux-x86_64
@@ -125,7 +125,7 @@ jobs:
           # Ensure the directory exists
           if [ -d "dist/aarch64" ]; then
             # Create tarball for aarch64
-            tar -czf dist/coveralls-linux-aarch64.tar.gz -C dist/aarch64 coveralls
+            tar -cvzf dist/coveralls-linux-aarch64.tar.gz -C dist/aarch64 coveralls
             # Create binary for upload
             cp dist/aarch64/coveralls dist/coveralls-linux-aarch64
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ ARG BASE_IMAGE_TAG=ubuntu-22.04
 # Stage 1: Build for x86_64
 FROM 84codes/crystal:${CRYSTAL_VERSION}-${BASE_IMAGE_TAG} AS builder-x86_64
 WORKDIR /app
+# Clone the coverage-reporter repository
 RUN git clone https://github.com/coverallsapp/coverage-reporter.git .
+# Install liblzma-dev and other dependencies
+RUN apt-get update && apt-get install -y liblzma-dev
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
     && shards build coveralls --production --release --static --no-debug --progress \
@@ -14,7 +17,10 @@ RUN shards install --production --ignore-crystal-version \
 # Stage 2: Build for aarch64
 FROM 84codes/crystal:${CRYSTAL_VERSION}-${BASE_IMAGE_TAG} AS builder-aarch64
 WORKDIR /app
+# Copy source code from the x86_64 build
 COPY --from=builder-x86_64 /app /app
+# Install liblzma-dev and other dependencies
+RUN apt-get update && apt-get install -y liblzma-dev
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
     && shards build coveralls --production --release --static --no-debug --progress \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # Clone the coverage-reporter repository
 RUN git clone https://github.com/coverallsapp/coverage-reporter.git .
 # Install liblzma-dev and other dependencies
-RUN apt-get update && apt-get install -y liblzma-dev
+RUN apt-get update && apt-get install -y liblzma-dev libicu-dev
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
     && shards build coveralls --production --release --static --no-debug --progress \
@@ -20,7 +20,7 @@ WORKDIR /app
 # Copy source code from the x86_64 build
 COPY --from=builder-x86_64 /app /app
 # Install liblzma-dev and other dependencies
-RUN apt-get update && apt-get install -y liblzma-dev
+RUN apt-get update && apt-get install -y liblzma-dev libicu-dev
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
     && shards build coveralls --production --release --static --no-debug --progress \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /app
 RUN git clone https://github.com/coverallsapp/coverage-reporter.git .
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
-    && mkdir -p /app/bin \
-    && shards build coveralls --production --release --static --no-debug --progress -o /app/bin/coveralls \
+    && shards build coveralls --production --release --static --no-debug --progress \
     && strip /app/bin/coveralls  # Reduce binary size
 
 # Stage 2: Build for aarch64
@@ -18,8 +17,7 @@ WORKDIR /app
 COPY --from=builder-x86_64 /app /app
 # Install production dependencies and build the binary
 RUN shards install --production --ignore-crystal-version \
-    && mkdir -p /app/bin \
-    && shards build coveralls --production --release --static --no-debug --progress -o /app/bin/coveralls \
+    && shards build coveralls --production --release --static --no-debug --progress \
     && strip /app/bin/coveralls  # Reduce binary size
 
 # Stage 3a: Export Binary for x86_64


### PR DESCRIPTION
#### :zap: Summary

Properly build statically linked binaries with the `shards build --production` command.

#### :ballot_box_with_check: Checklist

- [x] Properly compile statically linked binary with `shards build` command, using the correct target (`src/cli.cr`).
- [x] Compile with production dependencies only using the `--production` flag.
  - [x] Drop all dependency management steps required with previous `crystal build` method
- [x] Strip the binaries to reduce their size before the `build.yml` workflow archives them.
