### PR TITLE
Trigger test-binaries workflow to run after build workflow completes.

### DIFF
--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -2,6 +2,10 @@ name: Test Multi-Arch Linux Binaries After Build
 
 on:
   workflow_dispatch:  # Trigger manually or on schedule
+  workflow_run:
+    workflows: [ "Build" ]
+    types:
+      - completed
 
 jobs:
   test_binaries:

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -1,7 +1,6 @@
 name: Test Multi-Arch Linux Binaries After Build
 
 on:
-  workflow_dispatch:  # Trigger manually or on schedule
   workflow_run:
     workflows: [ "Build" ]
     types:


### PR DESCRIPTION
Closes # (issue(s))

- [x] https://github.com/coverallsapp/coverage-reporter/issues/137
- [x] https://github.com/coverallsapp/github-action/issues/218

#### :zap: Summary

Adds new trigger to workflow that test multi-architecture linux binaries to run after the workflow that builds the binaries completes.

#### :ballot_box_with_check: Checklist

- [x] Add `on: workflow_run: workflows: [ "Build" ], types: completed` to `test-binaries.yml`
