### PR TITLE
Test Linux Binaries after they're built in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -50,14 +50,14 @@ jobs:
           tar -acf coveralls-windows.zip coveralls.exe
 
       - name: Upload exe
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-windows.exe
           path: dist/coveralls.exe
           if-no-files-found: error
 
       - name: Upload zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-windows.zip
           path: dist/coveralls-windows.zip
@@ -72,7 +72,7 @@ jobs:
       #     echo "${{ toJson(github.event) }}"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -96,7 +96,7 @@ jobs:
         run: ls -la dist/
 
       - name: Upload linux binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coveralls-linux-binaries
           path: dist/*
@@ -106,43 +106,43 @@ jobs:
         run: echo "test-binaries-trigger" > test-binaries-trigger.txt
 
       - name: Upload Trigger Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-binaries-trigger
           path: test-binaries-trigger.txt
 
 #      - name: Upload coveralls-linux
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux
 #          path: dist/coveralls-linux
 #
 #      - name: Upload coveralls-linux.tar.gz
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux.tar.gz
 #          path: dist/coveralls-linux.tar.gz
 #
 #      - name: Upload coveralls-linux-x86_64
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux-x86_64
 #          path: dist/coveralls-linux-x86_64
 #
 #      - name: Upload coveralls-linux-x86_64.tar.gz
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux-x86_64.tar.gz
 #          path: dist/coveralls-linux-x86_64.tar.gz
 #
 #      - name: Upload coveralls-linux-aarch64
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux-aarch64
 #          path: dist/coveralls-linux-aarch64
 #
 #      - name: Upload coveralls-linux-aarch64.tar.gz
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coveralls-linux-aarch64.tar.gz
 #          path: dist/coveralls-linux-aarch64.tar.gz
@@ -158,7 +158,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -166,7 +166,7 @@ jobs:
         run: git fetch --force --tags
 
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
     steps:
       # Debug step to verify event context
       - name: Print event context for build-linux
-        run: echo "${{ toJson(github.event) }}"
+        run: |
+          echo "${{ toJson(github.event) }}"
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,15 +101,15 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-#      - name: Create Trigger File
-#        run: echo "test-binaries-trigger" > test-binaries-trigger.txt
-#
-#      - name: Upload Trigger Artifact
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: test-binaries-trigger
-#          path: test-binaries-trigger.txt
-#
+      - name: Create Trigger File
+        run: echo "test-binaries-trigger" > test-binaries-trigger.txt
+
+      - name: Upload Trigger Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-binaries-trigger
+          path: test-binaries-trigger.txt
+
 #      - name: Upload coveralls-linux
 #        uses: actions/upload-artifact@v3
 #        with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,10 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      # Debug step to verify event context
-      - name: Print event context for build-linux
-        run: |
-          echo "${{ toJson(github.event) }}"
+      # # Debug step to verify event context
+      # - name: Print event context for build-linux
+      #   run: |
+      #     echo "${{ toJson(github.event) }}"
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
@@ -43,7 +43,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -21,7 +21,9 @@ jobs:
 
       # Debug Step to Print Event Context
       - name: Print event context
-        run: echo "${{ toJson(github.event) }}"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
 
       # Debug step to list available artifacts
       - name: List available artifacts in dist/

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Debug Step to Print Event Context
-      - name: Print event context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      # # Debug Step to Print Event Context
+      # - name: Print event context
+      #   env:
+      #     GITHUB_CONTEXT: ${{ toJson(github) }}
+      #   run: echo "$GITHUB_CONTEXT"
 
       # Debug step to list available artifacts
       - name: List available artifacts in dist/

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # # Debug Step to Print Event Context
       # - name: Print event context
@@ -34,7 +34,7 @@ jobs:
         run: ls -la ./binaries/
 
       - name: Download built artifacts (linux binaries)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coveralls-linux-binaries
           path: ./binaries/
@@ -48,7 +48,7 @@ jobs:
         run: ls -la dist/
 
       - name: Download coverage report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report  # Assuming this is the name of the artifact from the build.yml run
           path: ./coverage/


### PR DESCRIPTION
#### :zap: Summary

Resolving issues with a new workflow, `test-binaries.yml` that attempts to test the latest versions of our multi-arch linux binaries in architecture-specific environments, just after they are built in CI.

#### :ballot_box_with_check: Checklist

- [x] Resolve issues with triggering of `test-binaries` workflow
