### PR TITLE
Test Linux Binaries after they're built in CI (Cont'd)

### DIFF
--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -25,14 +25,6 @@ jobs:
       #     GITHUB_CONTEXT: ${{ toJson(github) }}
       #   run: echo "$GITHUB_CONTEXT"
 
-      # Debug step to list available artifacts
-      - name: List available artifacts in dist/
-        run: ls -la dist/
-
-      # Debug step to list available artifacts
-      - name: List available artifacts in ./binaries/
-        run: ls -la ./binaries/
-
       - name: Download built artifacts (linux binaries)
         uses: actions/download-artifact@v4
         with:
@@ -42,10 +34,6 @@ jobs:
       # Debug step to list available artifacts
       - name: List available artifacts in ./binaries/
         run: ls -la ./binaries/
-
-      # Debug step to list available artifacts
-      - name: List available artifacts in dist/
-        run: ls -la dist/
 
       - name: Download coverage report
         uses: actions/download-artifact@v4


### PR DESCRIPTION
#### :zap: Summary

Resolve issues with workflow, `test-binaries.yml`, that attempts to test the latest versions of our multi-arch linux binaries in architecture-specific environments, just after they are built in CI.

#### :ballot_box_with_check: Checklist

- [x] Resolve syntax error caused by debug line in `test-binaries` workflow
