### PR TITLE
Test Linux Binaries after they're built in CI (Cont'd)

### DIFF
--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -1,0 +1,57 @@
+name: test-binaries-qemu
+
+on:
+  workflow_run:
+    workflows: [build]
+    types:
+      - completed
+
+jobs:
+  test-x86_64:
+    runs-on: ubuntu-22.04
+    steps:
+      # Debug step to list artifacts for the run
+      - name: List available artifacts
+        run: |
+          echo "Available artifacts:"
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+      - name: Download coveralls-linux-x86_64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: coveralls-linux-binaries
+          path: ./artifacts
+      - name: Verify binary
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          chmod +x ./artifacts/coveralls-linux-x86_64
+          ./artifacts/coveralls-linux-x86_64 --version
+          ./artifacts/coveralls-linux-x86_64 report --measure --base-path src/coverage_reporter/
+
+  test-aarch64:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch: [aarch64]
+    steps:
+      # Debug step to list artifacts for the run
+      - name: List available artifacts
+        run: |
+          echo "Available artifacts:"
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+      - name: Set up QEMU for aarch64 emulation
+        uses: docker/setup-qemu-action@v2
+      - name: Download coveralls-linux-aarch64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: coveralls-linux-binaries
+          path: ./artifacts
+      - name: Verify binary
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          chmod +x ./artifacts/coveralls-linux-aarch64
+          ./artifacts/coveralls-linux-aarch64 --version 
+          ./artifacts/coveralls-linux-aarch64 report --measure --base-path src/coverage_reporter/

--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           name: coveralls-linux-binaries
           path: ./artifacts
-      - name: Verify binary
+      - name: Test binary
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
@@ -31,9 +31,6 @@ jobs:
 
   test-aarch64:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        arch: [aarch64]
     steps:
       # Debug step to list artifacts for the run
       - name: List available artifacts
@@ -43,12 +40,14 @@ jobs:
           "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
       - name: Set up QEMU for aarch64 emulation
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64 # Or qemu-aarch64?
       - name: Download coveralls-linux-aarch64 binary
         uses: actions/download-artifact@v4
         with:
           name: coveralls-linux-binaries
           path: ./artifacts
-      - name: Verify binary
+      - name: Test binary
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |

--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -17,7 +17,7 @@ jobs:
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
       - name: Download coveralls-linux-x86_64 binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coveralls-linux-binaries
           path: ./artifacts
@@ -42,9 +42,9 @@ jobs:
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
       - name: Set up QEMU for aarch64 emulation
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Download coveralls-linux-aarch64 binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coveralls-linux-binaries
           path: ./artifacts

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # # Debug Step to Print Event Context
-      # - name: Print event context
-      #   env:
-      #     GITHUB_CONTEXT: ${{ toJson(github) }}
-      #   run: echo "$GITHUB_CONTEXT"
-
       # Debug step to list artifacts for the run
       - name: List available artifacts
         run: |

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -25,6 +25,13 @@ jobs:
       #     GITHUB_CONTEXT: ${{ toJson(github) }}
       #   run: echo "$GITHUB_CONTEXT"
 
+      # Debug step to list artifacts for the run
+      - name: List available artifacts
+        run: |
+          echo "Available artifacts:"
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+
       - name: Download built artifacts (linux binaries)
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
#### :zap: Summary

Resolve issues with workflow, `test-binaries.yml`, that attempts to test the latest versions of our multi-arch linux binaries in architecture-specific environments, just after they are built in CI.

#### :ballot_box_with_check: Checklist

- [x] Fix broken step in `test-binaries` workflow
