### PR TITLE
Test Linux Binaries after they're built in CI (Cont'd)

### DIFF
--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "Available artifacts:"
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq '.artifacts[] | .name'
       - name: Download coveralls-linux-x86_64 binary
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo "Available artifacts:"
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq '.artifacts[] | .name'
 
       - name: Download built artifacts (linux binaries)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
#### :zap: Summary

Resolve issues with workflow, `test-binaries.yml`, that attempts to test the latest versions of our multi-arch linux binaries in architecture-specific environments, right after they're built in CI.

Add new workflow, `test-binaries-qemu.yml` to test in QEMU emulation.

#### :ballot_box_with_check: Checklist

- [x] Add debug step to `test-binaries` workflow to assess artifact-download problem
- [x] Add new `test-binaries-qemu` workflow to test in QEMU emulation

