### PR TITLE
Test Linux Binaries after they're built in CI (Cont'd)

### DIFF
--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Download coveralls-linux-x86_64 binary
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           name: coveralls-linux-binaries
           path: ./artifacts
       - name: Test binary
@@ -37,7 +38,7 @@ jobs:
         run: |
           echo "Available artifacts:"
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | jq '.artifacts[] | .name'
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq '.artifacts[] | .name'
       - name: Set up QEMU for aarch64 emulation
         uses: docker/setup-qemu-action@v3
         with:
@@ -45,6 +46,7 @@ jobs:
       - name: Download coveralls-linux-aarch64 binary
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           name: coveralls-linux-binaries
           path: ./artifacts
       - name: Test binary

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Download built artifacts (linux binaries)
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           name: coveralls-linux-binaries
           path: ./binaries/
 


### PR DESCRIPTION
#### :zap: Summary

Resolve issues with workflows, `test-binaries.yml` and `test-binaries-qemu.yml`, that attempt to test the latest versions of our multi-arch linux binaries in architecture-specific environments, right after they're built in CI.

#### :ballot_box_with_check: Checklist

- [x] Trigger CI to re-test updated `test-binaries` and `test-binaries-qemu` workflows on `master`
- [x] Correct the Run ID for artifact-download steps in `test-*.yml` workflows; should be the ID of the triggering workflow `build.yml`

