### PR TITLE
Test Linux Binaries after they're built in CI (Cont'd)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,11 +123,11 @@ jobs:
 #          name: coveralls-linux.tar.gz
 #          path: dist/coveralls-linux.tar.gz
 #
-#      - name: Upload coveralls-linux-x86_64
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: coveralls-linux-x86_64
-#          path: dist/coveralls-linux-x86_64
+      - name: Upload coveralls-linux-x86_64
+        uses: actions/upload-artifact@v4
+        with:
+          name: coveralls-linux-x86_64
+          path: dist/coveralls-linux-x86_64
 #
 #      - name: Upload coveralls-linux-x86_64.tar.gz
 #        uses: actions/upload-artifact@v4
@@ -135,11 +135,11 @@ jobs:
 #          name: coveralls-linux-x86_64.tar.gz
 #          path: dist/coveralls-linux-x86_64.tar.gz
 #
-#      - name: Upload coveralls-linux-aarch64
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: coveralls-linux-aarch64
-#          path: dist/coveralls-linux-aarch64
+      - name: Upload coveralls-linux-aarch64
+        uses: actions/upload-artifact@v4
+        with:
+          name: coveralls-linux-aarch64
+          path: dist/coveralls-linux-aarch64
 #
 #      - name: Upload coveralls-linux-aarch64.tar.gz
 #        uses: actions/upload-artifact@v4

--- a/.github/workflows/test-binaries-qemu.yml
+++ b/.github/workflows/test-binaries-qemu.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          name: coveralls-linux-binaries
+          name: coveralls-linux-x86_64
           path: ./artifacts
       - name: Test binary
         env:
@@ -47,7 +47,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          name: coveralls-linux-binaries
+          name: coveralls-linux-aarch64
           path: ./artifacts
       - name: Test binary
         env:

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -26,12 +26,26 @@ jobs:
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq '.artifacts[] | .name'
 
-      - name: Download built artifacts (linux binaries)
+      # - name: Download built artifacts (linux binaries)
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     run-id: ${{ github.event.workflow_run.id }}
+      #     name: coveralls-linux-binaries
+      #     path: ./binaries/
+
+      - name: Download built x86_64 binary
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          name: coveralls-linux-binaries
+          name: coveralls-linux-x86_64
           path: ./binaries/
+
+      - name: Download built aarch64 binary
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: coveralls-linux-aarch64
+          path: ./binaries/          
 
       # Debug step to list available artifacts
       - name: List available artifacts in ./binaries/


### PR DESCRIPTION
#### :zap: Summary

Resolve issues with workflows, `test-binaries.yml` and `test-binaries-qemu.yml`, that attempt to test the latest versions of our multi-arch linux binaries in architecture-specific environments, right after they're built in CI.

#### :ballot_box_with_check: Checklist

- [x] Trigger CI to re-test updated `test-binaries` and `test-binaries-qemu` workflows on `master`
- [x] Switch to uploading and downloading binary files individually.

