### PR TITLE
Fix statement that creates coveralls-checksums.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
           cp -r artifacts/coveralls-linux-binaries/* release/
           find artifacts/ -type f -exec cp \{} release/ \;
           mv release/coveralls.exe release/coveralls-windows.exe
-          sha256sum release/* > release/coveralls-checksums.txt
+          (cd release && sha256sum * > coveralls-checksums.txt)
 
       - name: List files in release directory (debug)
         run: |


### PR DESCRIPTION
#### Closes:

Actually, we closed these issues with a **patch** in which we downloaded, changed, and re-uploaded the `coveralls-checksums.txt` file to release `v.0.6.15`, but this fix makes sure the same issue won't occur in future releases:

- #165 
- https://github.com/coverallsapp/github-action/issues/224
- https://github.com/coverallsapp/orb/issues/45

#### :zap: Summary

Fixes the statement that creates the `coveralls-checksums.txt` file.

#### :ballot_box_with_check: Checklist

- [x] Fixes the statement that creates the `coveralls-checksums.txt` file:
    - [x] `cd` into `release/` directory before creating checksums on each file (so we leave out the path prefix, `release/`). 

    **Reasoning**: These files will be downloaded at the root level for users of each binary, so the checksums need to refer to the files without any paths included.
