### PR TITLE
Update crystal version to 1.17 to incorporate xml shard fixes causing…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.13.2
+          crystal: 1.17.1
 
       - name: Build SQLite3 static library
         run: "scripts/sqlite3-static.ps1"
@@ -77,7 +77,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.13.2
+          crystal: 1.17.1
 
       - name: Install shards dependencies
         run: shards install --production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.13.2
+        crystal: 1.17.1
     - name: Install dependencies
       run: shards install
     - name: Install coverage.py
@@ -34,7 +34,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.13.2
+        crystal: 1.17.1
     - name: Install dependencies
       run: shards install
     - name: Run linter
@@ -48,7 +48,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.13.2
+        crystal: 1.17.1
     - run: make build
 
     - name: Install kcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Source: https://forum.crystal-lang.org/t/cross-compiling-crystal-applications-part-1/6956
 # Repo: https://github.com/luislavena/crystal-xbuild-container
 # Background Crystal Lang Docs on:
-# - Cross-Compilation: https://crystal-lang.org/reference/1.13/syntax_and_semantics/cross-compilation.html
-# - Static Linking: https://crystal-lang.org/reference/1.13/guides/static_linking.html
+# - Cross-Compilation: https://crystal-lang.org/reference/7/syntax_and_semantics/cross-compilation.html
+# - Static Linking: https://crystal-lang.org/reference/1.17/guides/static_linking.html
 #
 # NOTE:
 # We've modified the original approach here as necessary for coverage-reporter:
@@ -15,7 +15,7 @@
 # ---
 
 # Base image from luislavena's hydrofoil-crystal image
-FROM ghcr.io/luislavena/hydrofoil-crystal:1.13 AS base
+FROM ghcr.io/luislavena/hydrofoil-crystal:1.17 AS base
 
 # install cross-compiler (Zig) with dependencies and utilities
 RUN --mount=type=cache,sharing=private,target=/var/cache/apk \

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: coverage-reporter
 version: 0.6.16
-crystal: ">= 1.7.2"
+crystal: ">= 1.17.1"
 license: MIT
 
 authors:


### PR DESCRIPTION
Update crystal version to 1.17 to incorporate xml shard fixes causing segfault on macos 15.4+.

Closes # (issues)

- https://github.com/coverallsapp/homebrew-coveralls/issues/65
- https://github.com/coverallsapp/github-action/issues/248

#### :zap: Summary

Update crystal version to 1.17 to incorporate xml shard fixes causing segfault on macos 15.4+.

#### :ballot_box_with_check: Checklist

Bump version inL

- [x] `shard.yml`
- [x] `build.yml` workflow
- [x] `ci.yml` workflow
- [x] `Dockerfile`
