### PR TITLE
Fix homebrew formula bump: upgrade bump-formula action v3 → v8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
+        uses: dawidd6/action-homebrew-bump-formula@v8
         with:
           tap: coverallsapp/coveralls
           formula: coveralls


### PR DESCRIPTION
## Problem

The `homebrew` job failed on the [v0.6.18 release run](https://github.com/coverallsapp/coverage-reporter/actions/runs/31750044558):

```
Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap
coverallsapp/coveralls. (Homebrew::UntrustedTapError)
Run `brew trust --formula coverallsapp/coveralls/coveralls` or
`brew trust coverallsapp/coveralls` to trust it.
```

Homebrew 6.0.0+ requires taps to be explicitly trusted before their formulae can be loaded. We were pinned to `dawidd6/action-homebrew-bump-formula@v3`, which predates that requirement and never calls `brew trust` — so the action died as soon as it tried to load the formula.

**This is unrelated to the v0.6.18 code changes.** It's the first release since Homebrew introduced tap trust, so it would have broken any release.

## Why it went unnoticed

The `homebrew` job is gated behind `release`, which is gated behind `build-linux` — and `build-linux` had been failing since ~May 2026. The job hadn't run since Sept 2025. The breakage was masked by a different breakage; fixing `build-linux` (#192) is what finally let it surface.

## Fix

Upgrade to `@v8`, which runs `brew trust <tap>` before loading the formula ([`main.rb:91`](https://github.com/dawidd6/action-homebrew-bump-formula/blob/v8/main.rb#L91)).

Verified this is a drop-in upgrade — the `token`, `tap`, and `formula` inputs are unchanged between v3 and v8, and `tag` / `revision` keep the same defaults (`${{github.ref}}` / `${{github.sha}}`).

We already made the equivalent change on the *install* side in [`coverallsapp/github-action`](https://github.com/coverallsapp/github-action) (using the fully-qualified formula name so `brew install` trusts the formula). The *bump* side never got the same treatment.

## Impact until this lands

The tap formula still points at `v0.6.17`, so **MacOS users stay on 0.6.17** — they get the reporter via `brew install` rather than the release assets, including on MacOS GitHub Actions runners. Linux and Windows users already have v0.6.18 from the release assets.

## Important: merging this does NOT retroactively fix v0.6.18

Re-running the `homebrew` job on the existing `v0.6.18` tag will **fail identically**. A workflow re-run uses the workflow file from the commit that triggered it, and `git show v0.6.18:.github/workflows/build.yml` still contains `@v3`. Merging to `master` does not change what the tag points at.

To actually get MacOS users onto the current release, one of:

1. **Cut the next release after merging this** — the new tag includes `@v8`, so the bump runs correctly. Validates the fixed automation end to end.
2. **Bump the tap formula manually** — open a PR against `coverallsapp/homebrew-coveralls` updating `url` and `sha256` to the `v0.6.18` tarball, then label it `pr-pull` so `publish.yml` builds and pulls the bottles.

Note that even when the automation works, it opens a PR against the tap that still needs the `pr-pull` label to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
