### PR TITLE
Add Dependabot for GitHub Actions and Docker base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot keeps our release-path dependencies from silently drifting.
+#
+# Context: the v0.6.18 release surfaced three separate breakages, all caused by
+# external drift in infrastructure that had not run since Sept 2025 -- including
+# `dawidd6/action-homebrew-bump-formula` sitting five major versions behind,
+# which broke the Homebrew formula bump once Homebrew 6.0.0 introduced tap trust.
+# Dependabot would have flagged that long before it broke a release.
+#
+# NOTE: There is no Dependabot ecosystem for Crystal shards, so `shard.yml` /
+# `shard.lock` are not covered here and still need manual review.
+version: 2
+updates:
+  # GitHub Actions used by ci.yml and build.yml (including the release and
+  # Homebrew formula-bump jobs).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Base image for the cross-compilation container (Dockerfile), which produces
+  # our released Linux binaries.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Why

The v0.6.18 release surfaced **three separate breakages**, all caused by external drift in release infrastructure that hadn't run since Sept 2025:

1. Homebrew's formula index gained entries with no `stable` bottle → broke the xbuild container build (#192)
2. Homebrew 6.0.0 introduced tap trust, and `dawidd6/action-homebrew-bump-formula` was pinned at **v3** while upstream was at **v8** → broke the formula bump (#194)
3. Homebrew changed the Linux zlib provider and tightened `brew linkage` → broke the tap formula ([homebrew-coveralls#74](https://github.com/coverallsapp/homebrew-coveralls/pull/74))

Each was hidden behind the previous one. **Dependabot would have flagged #2 long before it broke a release.**

## What this covers

| Ecosystem | Watches |
|---|---|
| `github-actions` | The 6 actions across `ci.yml` and `build.yml`, including the `release` and `homebrew` jobs |
| `docker` | `ghcr.io/luislavena/hydrofoil-crystal:1.17` — the base image for the cross-compilation container that builds our released Linux binaries |

Currently pinned actions it will track:

```
actions/checkout@v4
actions/download-artifact@v4
actions/upload-artifact@v4
crystal-lang/install-crystal@v1
dawidd6/action-download-artifact@v6
dawidd6/action-homebrew-bump-formula@v8
```

Weekly, capped at 5 open PRs per ecosystem so it stays reviewable.

## Not covered

There is no Dependabot ecosystem for Crystal shards, so `shard.yml` / `shard.lock` still need manual review.

## Notes

This is a config file, not a workflow — GitHub reads it once merged to the default branch. **No release required**, and it changes nothing about the shipped binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)