### PR TITLE
ci: build every shipped binary with the xbuild container's Crystal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.17.1
+          # NOTE: keep this in step with the Crystal version in the xbuild container's
+          # base image (Dockerfile `FROM ghcr.io/luislavena/hydrofoil-crystal:<tag>`),
+          # so every binary we ship is built by the same compiler.
+          crystal: 1.21.0
 
       - name: Build SQLite3 static library
         run: "scripts/sqlite3-static.ps1"
@@ -77,7 +80,8 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.17.1
+          # Keep in step with the xbuild container (see note in build-windows).
+          crystal: 1.21.0
 
       - name: Install shards dependencies
         run: shards install --production


### PR DESCRIPTION
## What this does

[#197](https://github.com/coverallsapp/coverage-reporter/pull/197) bumped the xbuild container to `hydrofoil-crystal:1.21`, so released **Linux** binaries are built with Crystal **1.21.0**. The `build.yml` pins stayed at **1.17.1**, so the shipped **Windows** `.exe` was compiled by a different compiler than the Linux binaries.

This pins both `build.yml` jobs to 1.21.0, so **every artifact we ship comes from one compiler**.

Both jobs run `shards install --production`, so no dev dependencies (and therefore no linter) are involved.

## Scope: deliberately narrowed

This PR originally also pinned the three `ci.yml` jobs to 1.21.0 and updated `shard.lock`. That version is preserved at `358b04a` / `cb1161c` if we want it back. It was narrowed because pinning **CI** to 1.21 pulls in a dependency chain that isn't worth taking right now:

- **ameba 1.5.0 does not compile under Crystal 1.21** — `undefined method 'next_string_array_token' for Crystal::Lexer` in `src/ameba/tokenizer.cr:88`.
- **No released ameba fixes this.** v1.6.4 fails with the identical error. The fix exists only on ameba `master` (1.7.0-dev).
- **ameba master declares `crystal: ~> 1.19`**, so pinning CI to 1.21 would raise the *development* floor to Crystal ≥1.19. `shard.yml`'s `>= 1.17.1` (the floor for building from source) would be unchanged, but contributors on older Crystal could no longer `shards install`.
- **ameba master removed its `scripts: postinstall: shards build -Dpreview_mt` block**, which is what creates `bin/ameba`. The `lint` job would need changing from `bin/ameba` to `shards build ameba && bin/ameba`.

None of that blocks shipping correct binaries, which is what this PR is actually about.

## What's left for a follow-up

Aligning `ci.yml` too is a bounded piece of work — worth doing once ameba 1.7.0 ships as a real release rather than pinning to an unreleased commit:

1. **Three deprecation fixes.** `crystal spec` runs with `--error-on-warnings`, and Crystal 1.21 newly deprecates:
   - `src/coverage_reporter/reporter.cr:90` and `:95` — `Time.monotonic` → `Time.instant`
   - `src/coverage_reporter/cli/cmd.cr:375` — `Colorize.on_tty_only!` → remove (it's the default since Crystal 1.17)

   Worth noting the earlier CI run's `test (macos-latest)` failure was **not** a test failure — it reported `124 examples, 0 failures` and then exited 1 purely on those warnings.

2. **One line in `ci.yml`** so the linter gets built (see above). The earlier `lint` failure was `bin/ameba: No such file or directory`, exit 127 — ameba never ran.

3. **65 ameba 1.7 findings** (measured by building ameba `f53fcd3` under Crystal 1.21 and running it against this repo): 62 files inspected, **64 Convention + 1 Warning, zero errors**.

   | Rule | Count |
   |---|---|
   | `Naming/BlockParameterName` | 27 |
   | `Style/PercentLiteralDelimiters` | 16 |
   | `Style/VerboseNilType` | 13 |
   | `Style/HeredocIndent` | 3 |
   | `Style/RedundantSelf` | 2 |
   | `Style/RedundantNilInControlExpression` | 2 |
   | `Style/MultilineStringLiteral` | 1 |
   | `Lint/UnusedRescueVariable` | 1 |

   26 are `[Correctable]` (`ameba --fix`); 47 in `src/`, 18 in `spec/`. All style — nothing touching correctness. `.ameba.yml` was originally produced by `ameba --gen-config`, so regenerating it is also a valid way to go green and burn down later.

Separately worth considering: `shard.yml` declares ameba as `branch: master` (unpinned), which is how it drifted to a 2023-era commit in the first place.
