### PR TITLE
chore: ignore build artifacts that `git add -A` can pick up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .coveralls.yml
 /.crystal/
+.crystal-cache
 /.shards/
 /.vagrant/
 /bin/
@@ -10,7 +11,7 @@
 /dist
 /docs/
 /insecure_private_keys
-/lib/
+/lib
 coverage.xml
-.venv/
+.venv
 .vscode/


### PR DESCRIPTION
Hygiene only — no `src/` or spec changes.

Three patterns in `.gitignore` are narrower than intended, so local build artifacts show up as untracked files and can be swept into a commit by `git add -A`:

| Pattern | Problem |
|---|---|
| `/lib/` | Directory-only, so it does not match a **symlink** named `lib` |
| `.venv/` | Same |
| *(absent)* | `.crystal-cache` was not ignored at all |

Symlinking `lib` and `.venv` into a scratch git worktree is a normal way to run the suite without a second `shards install`, and pointing `CRYSTAL_CACHE_DIR` inside the tree leaves thousands of compiler objects untracked. Combined, a single `git add -A` can stage ~3,000 unintended files.

Verified with `git check-ignore` in a scratch repo — `/lib/` leaves a `lib` symlink unignored, `/lib` catches both directory and symlink:

```
$ printf '/lib/\n.venv/\n' > .gitignore && ln -s /tmp lib && ln -s /tmp .venv
$ git check-ignore -v lib .venv
(no output — neither ignored)

$ printf '/lib\n.venv\n' > .gitignore
$ git check-ignore -v lib .venv
.gitignore:1:/lib      lib
.gitignore:2:.venv     .venv
```

The new `.crystal-cache` entry is deliberately unanchored so it applies at any depth, rather than repeating the too-narrow pattern this PR is fixing.

### Scope

This does **not** cover `spec/fixtures/python/.coverage`, which is a *tracked* binary fixture that the spec suite deletes and regenerates — `.gitignore` cannot help with a tracked file. Filed separately.

No effect on the release process, which stages explicit paths (`git add shard.yml src/coverage_reporter.cr`) rather than `-A`. Safe to land before or after v0.6.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)