### PR TITLE
chore: keep python spec artifacts out of the working tree

### DIFF
--- a/spec/fixtures/python/.gitignore
+++ b/spec/fixtures/python/.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 # artifact, not a fixture -- committing it makes every local `make test` run
 # show a spurious deletion in `git status`.
 .coverage
+
+# pytest treats this directory as its rootdir (see pytest.ini), so its cache
+# lands here too. Also a build artifact of the same spec suite hook.
+.pytest_cache/

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -30,6 +30,8 @@ Spectator.configure do |config|
   end
 
   config.after_suite do
-    File.delete("spec/fixtures/python/.coverage")
+    # delete? so a failed before_suite (or an aborted run) surfaces the real
+    # error instead of a File::NotFoundError from teardown.
+    File.delete?("spec/fixtures/python/.coverage")
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes stop the Python spec suite from leaving artifacts in the working tree, and stop its teardown from hiding real failures.

### Ignore the pytest cache

`spec/fixtures/python/pytest.ini` makes that directory pytest's rootdir, so the `coverage run -m pytest` call in `before_suite` writes `.pytest_cache/` there. Nothing removed it and nothing ignored it, so every local `make test` left an untracked directory behind — the same `git add -A` trap #204 fixed for `.coverage`, in the same directory.

### Don't mask suite errors in teardown

`after_suite` removed `spec/fixtures/python/.coverage` with `File.delete`, which raises `File::NotFoundError` when the file is absent. If `before_suite` failed, or the run was interrupted before the file was written, that teardown error replaced the real failure. `File.delete?` is a no-op when the file is missing.