### PR TITLE
test: isolate jobs_spec from ambient CI env vars

### DIFF
--- a/spec/coverage_reporter/api/jobs_spec.cr
+++ b/spec/coverage_reporter/api/jobs_spec.cr
@@ -69,12 +69,23 @@ Spectator.describe CoverageReporter::Api::Jobs do
     body.to_s
   end
 
+  # `request_body` above is built from `Config#to_h`, which gains service_name,
+  # service_number and friends as soon as a CI provider is detected. Under GitHub
+  # Actions the real GITHUB_* vars are present, so the stubbed body and the request
+  # `Api::Jobs` actually builds can disagree -- WebMock then matches no stub and
+  # raises NetConnectNotAllowedError instead of the expected error. Whether that
+  # happened depended on whether config_spec or webhook_spec (which clear these in
+  # their own hooks) had already run, so with `config.randomize` it came and went
+  # at random. webhook_spec had the same problem and clears the vars for the same
+  # reason; this spec was the last one still exposed.
   before_each do
+    delete_env_vars
     ENV["COVERALLS_RUN_AT"] = Time::Format::RFC_3339.format(Time.local)
   end
 
   after_each do
     WebMock.reset
+    delete_env_vars
     ENV.delete("COVERALLS_RUN_AT")
   end
 


### PR DESCRIPTION
Hardening for the intermittent `jobs_spec` failure tracked in #209.

## Problem

`jobs_spec` builds its expected `request_body` from `Config#to_h`, which gains
`service_name`, `service_number` and friends as soon as a CI provider is detected.
Under GitHub Actions the real `GITHUB_*` vars are present, so the stubbed body and
the request `Api::Jobs` actually builds can disagree — WebMock then matches no stub
and raises `NetConnectNotAllowedError` instead of the expected error.

Whether that happens depends on execution order. `config_spec` and `webhook_spec`
call `delete_env_vars` in their own hooks and never restore what they deleted, so
with `config.randomize` on, whether those vars are still set when `jobs_spec` runs
varies per run.

`webhook_spec` hit this exact failure before and carries a comment describing it.
`jobs_spec` was the last ENV-sensitive spec that had not been given the same
treatment.

Observed on `test (macos-latest)` at 16eee3a in
[run 32201842605](https://github.com/coverallsapp/coverage-reporter/actions/runs/32201842605),
while `test (ubuntu-22.04)` passed on the same commit.

## Change

Adds `delete_env_vars` to `jobs_spec`'s `before_each`/`after_each`, mirroring
`webhook_spec`, plus a comment explaining why.

Spec-only. No change to `src/`, so no behaviour change and no release needed.

## Honest caveat

**This is hardening by precedent, not a verified fix.** The failure did not reproduce
locally across roughly 60 runs — full suite, full suite with `GITHUB_*` set, and the
three ENV-sharing specs forced together. #209 stays open rather than being closed by
this PR, so that a recurrence lands on an existing record.

## Testing

`make test` — 149 examples, 0 failures, including 6 consecutive runs with `GITHUB_*`
set to simulate the CI environment. `make lint` — 67 inspected, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)