### PR TITLE
fix: pin Crystal to 1.20.3 to stop random "execution_context" crashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,16 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    # Hold the Crystal toolchain at 1.20.x.
+    #
+    # Dependabot proposed the 1.17 -> 1.21 bump in #197, we merged it, and it
+    # shipped a runtime regression in v0.6.19/v0.6.20 that crashed customer CI
+    # jobs at random ("Thread#execution_context cannot be nil"). Crystal 1.21
+    # turns on execution contexts by default; see the long note in the
+    # Dockerfile and https://github.com/crystal-lang/crystal/issues/17212.
+    #
+    # Remove this ignore only when #17212 is fixed upstream AND a rebuilt
+    # binary has been checked for the "SYSMON" string.
+    ignore:
+      - dependency-name: "ghcr.io/luislavena/hydrofoil-crystal"
+        versions: [">= 1.21"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,11 @@ jobs:
           # NOTE: keep this in step with the Crystal version in the xbuild container's
           # base image (Dockerfile `FROM ghcr.io/luislavena/hydrofoil-crystal:<tag>`),
           # so every binary we ship is built by the same compiler.
-          crystal: 1.21.0
+          #
+          # Held at 1.20.x on purpose: Crystal 1.21's default runtime crashes at
+          # random with "Thread#execution_context cannot be nil". See the note in
+          # the Dockerfile before changing this.
+          crystal: 1.20.3
 
       - name: Build SQLite3 static library
         run: "scripts/sqlite3-static.ps1"
@@ -81,7 +85,7 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           # Keep in step with the xbuild container (see note in build-windows).
-          crystal: 1.21.0
+          crystal: 1.20.3
 
       - name: Install shards dependencies
         run: shards install --production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.17.1
+        # Keep in step with the compiler that builds our released binaries
+        # (Dockerfile `FROM ghcr.io/luislavena/hydrofoil-crystal:<tag>` and the
+        # `crystal:` pins in build.yml). Testing on a different version than we
+        # ship is how the v0.6.19 execution-context regression reached users:
+        # specs ran on 1.17.1 while releases were built on 1.21.0.
+        crystal: 1.20.3
     - name: Install dependencies
       run: shards install
     - name: Install coverage.py
@@ -34,7 +39,8 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.17.1
+        # Keep in step with build.yml (see note in the `test` job).
+        crystal: 1.20.3
     - name: Install dependencies
       run: shards install
     - name: Run linter
@@ -48,7 +54,8 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.17.1
+        # Keep in step with build.yml (see note in the `test` job).
+        crystal: 1.20.3
     - run: make build
 
     - name: Install kcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,26 @@
 # ---
 
 # Base image from luislavena's hydrofoil-crystal image
-FROM ghcr.io/luislavena/hydrofoil-crystal:1.21
+#
+# PINNED TO 1.20.x -- DO NOT BUMP TO 1.21+ WITHOUT READING THIS.
+#
+# Crystal 1.21 enables execution contexts (RFC 0002) by default. That runtime
+# starts a bare `SYSMON` monitor thread which has no execution context of its
+# own, and it races with main-thread initialization. When it loses the race the
+# process dies with:
+#
+#   Unhandled exception: Thread#execution_context cannot be nil (NilAssertionError)
+#
+# We shipped that in v0.6.19 and v0.6.20 (the container bump landed in #197) and
+# it broke customer CI jobs at random. It is an open upstream regression:
+# https://github.com/crystal-lang/crystal/issues/17212
+#
+# 1.20.3 is the newest Crystal whose *default* runtime predates execution
+# contexts, so binaries built here are unaffected. Dependabot is configured to
+# hold this back (see .github/dependabot.yml). Revisit once #17212 is fixed and
+# released, and verify a rebuilt binary contains no "SYSMON" string before
+# accepting the bump.
+FROM ghcr.io/luislavena/hydrofoil-crystal:1.20.3
 
 # install cross-compiler (Zig) with dependencies and utilities
 RUN --mount=type=cache,sharing=private,target=/var/cache/apk \

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: coverage-reporter
 version: 0.6.20
-crystal: ">= 1.17.1"
+crystal: ">= 1.20.0"
 license: MIT
 
 authors:

--- a/src/coverage_reporter/reporter.cr
+++ b/src/coverage_reporter/reporter.cr
@@ -87,12 +87,12 @@ module CoverageReporter
 
     private def measure(name : String, &)
       return yield unless settings.measure
-      start = Time.monotonic
+      start = Time.instant
 
       yield
     ensure
       if start
-        elapsed_time = Time.monotonic - start
+        elapsed_time = Time.instant - start
         Log.info("⏱️ #{name}: #{elapsed_time}")
       end
     end


### PR DESCRIPTION
#### :zap: Summary

**v0.6.19 and v0.6.20 Linux binaries crash at random**, killing customer CI jobs:

```
Unhandled exception: Thread#execution_context cannot be nil (NilAssertionError)
from ???
```

Reported by a customer whose Java/Jacoco builds started failing right after the 0.6.19 update. **Jacoco is a red herring** — nothing format-specific is involved.

**Cause is our toolchain.** #197 bumped the xbuild container from `hydrofoil-crystal:1.17` to `:1.21`, which shipped in v0.6.19. [Crystal 1.21 enables execution contexts (RFC 0002) by default](https://crystal-lang.org/2026/07/16/1.21.0-released/). That runtime starts a bare `SYSMON` monitor thread which has no execution context of its own, and it races with main-thread initialization. It is an open, unfixed upstream regression — crystal-lang/crystal#17212 (`kind:regression`; fix PR crystal-lang/crystal#17214 still unmerged). Upstream's own diagnosis:

> the monitor thread is a bare thread, it doesn't have an execution context, hence no scheduler to suspend or resume the fiber

#### :mag: Evidence

The error string is compiled into our releases only from 0.6.19 on, so the reported crash **cannot** come from 0.6.18 or earlier:

| binary | `SYSMON` | `"Thread#execution_context cannot be nil"` |
|---|---|---|
| 0.6.17, 0.6.18 | absent | **absent** |
| 0.6.19, 0.6.20 (x86_64 + aarch64) | present | **present** |

#### :hammer: Fix

Pin to **Crystal 1.20.3** — the newest release whose *default* runtime predates execution contexts. Verified end-to-end: rebuilt the xbuild container on 1.20.3, cross-compiled a real static aarch64 binary, confirmed **0 `SYSMON`, 0 execution-context strings**, and confirmed the full detect → parse → POST path behaves identically to 0.6.17.

Also in this PR:

- **`ci.yml` moves from 1.17.1 to 1.20.3.** Specs ran on 1.17.1 while releases were built on 1.21.0 — we were never testing the runtime we distribute, which is how this reached users. Verified on 1.20.3: **149 examples, 0 failures** with `--error-on-warnings`, and ameba clean.
- **Dependabot now holds the base image below 1.21.** Dependabot opened #197 in the first place and would otherwise re-propose the identical bump next week.

Each pin carries an inline comment explaining why, so this does not get quietly undone.

#### :recycle: Revisit when

crystal-lang/crystal#17212 is fixed and released. Before accepting a future bump, rebuild and check the binary contains no `SYSMON` string.

#### :ballot_box_with_check: Checklist

- [x] Add specs — n/a; this is a build-toolchain pin. Regression coverage is the binary-string check above, and `ci.yml` now exercises the shipped compiler.