### PR TITLE
fix: build with libevent event loop so binaries start in sandboxed runtimes

### DIFF
--- a/.github/seccomp/no-clock-boottime.json
+++ b/.github/seccomp/no-clock-boottime.json
@@ -1,0 +1,30 @@
+{
+  "_comment": [
+    "Seccomp profile that models a sandboxed container runtime (gVisor and",
+    "similar), which implements timerfd_create() for CLOCK_REALTIME and",
+    "CLOCK_MONOTONIC only and returns EINVAL for CLOCK_BOOTTIME (clockid 7).",
+    "",
+    "Crystal >= 1.19 asks for a CLOCK_BOOTTIME timerfd while starting its",
+    "event loop, so a binary built that way aborts before main() in those",
+    "runtimes -- even `coveralls --version` fails. That shipped in v0.6.19,",
+    "v0.6.20 and v0.6.21 and broke a customer's CI for a week.",
+    "",
+    "Used by the regression gate in .github/workflows/build.yml. Everything",
+    "else is allowed; only the one clockid is rejected."
+  ],
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "archMap": [
+    { "architecture": "SCMP_ARCH_X86_64", "subArchitectures": ["SCMP_ARCH_X86", "SCMP_ARCH_X32"] },
+    { "architecture": "SCMP_ARCH_AARCH64", "subArchitectures": [] }
+  ],
+  "syscalls": [
+    {
+      "names": ["timerfd_create"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 22,
+      "args": [
+        { "index": 0, "value": 7, "op": "SCMP_CMP_EQ" }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,37 @@ jobs:
           echo $binary
           chmod +x $binary
           $binary --version
-      
+
+      # REGRESSION GATE -- do not delete without reading this.
+      #
+      # v0.6.19, v0.6.20 and v0.6.21 all shipped binaries that could not start
+      # at all in sandboxed container runtimes (gVisor and similar, which back
+      # Cloud Run, GKE Autopilot and several CI providers). Those runtimes
+      # implement timerfd_create() for CLOCK_REALTIME/CLOCK_MONOTONIC only and
+      # return EINVAL for CLOCK_BOOTTIME, which Crystal >= 1.19 requests while
+      # starting its default event loop. Affected users saw 100% failure, even
+      # on `coveralls --version`.
+      #
+      # Ordinary CI could never catch it: GitHub runners and Docker Desktop use
+      # a real kernel, where CLOCK_BOOTTIME timerfds work fine. So we reproduce
+      # the sandbox with a seccomp profile and run the actual shipped binary
+      # under it. See scripts/xbuild.sh for the `-Devloop=libevent` fix.
+      - name: Regression check - starts in a sandboxed runtime (no CLOCK_BOOTTIME timerfd)
+        run: |
+          set -euo pipefail
+          chmod +x test/coveralls-linux-x86_64
+          if ! docker run --rm \
+              --security-opt seccomp=.github/seccomp/no-clock-boottime.json \
+              -v "$PWD/test:/test:ro" \
+              alpine:3 /test/coveralls-linux-x86_64 --version; then
+            echo "::error::Binary fails to start when CLOCK_BOOTTIME timerfds are unavailable."
+            echo "::error::This is the v0.6.19-v0.6.21 regression. Check that scripts/xbuild.sh"
+            echo "::error::still passes -Devloop=libevent, and that the Crystal version in the"
+            echo "::error::Dockerfile has not moved somewhere that reintroduces timerfd startup."
+            exit 1
+          fi
+
+
       - name: Download latest coverage report for coverage-reporter from ci.yml
         uses: dawidd6/action-download-artifact@v23
         with:

--- a/scripts/xbuild.sh
+++ b/scripts/xbuild.sh
@@ -52,7 +52,32 @@ object_file="${TMPDIR:-/tmp}/$(basename "${filename%.*}-$target_platform.o")"
 
 # capture output from build
 pkg_config_libdir="$multiarch_root/$target_platform/lib/pkgconfig"
-build_cmd="crystal build --release --no-debug --static --cross-compile --target $target_platform"
+
+# `-Devloop=libevent` is required, not a tuning knob.
+#
+# Crystal >= 1.19 creates a CLOCK_BOOTTIME timerfd while starting its default
+# (epoll) event loop. Sandboxed container runtimes -- gVisor and friends, which
+# back Cloud Run, GKE Autopilot and several CI providers -- implement
+# timerfd_create() for CLOCK_REALTIME and CLOCK_MONOTONIC only and return EINVAL
+# for CLOCK_BOOTTIME. The event loop is built during startup, so the binary dies
+# before main() with a (misleadingly named) error:
+#
+#   Unhandled exception: timerfd_settime: Invalid argument (RuntimeError)
+#
+# even for `coveralls --version`. Crystal 1.21 hits the same wall a step earlier
+# and reports it as "Thread#execution_context cannot be nil" instead. This broke
+# v0.6.19, v0.6.20 and v0.6.21 for every user on such a runtime -- 100% of runs,
+# not intermittently.
+#
+# The libevent loop does not use timerfd at all, so it sidesteps the whole
+# problem rather than trading one clock for another. Upstream change that
+# introduced it: https://github.com/crystal-lang/crystal/pull/16516
+#
+# Guarded by the regression gate in .github/workflows/build.yml, which runs the
+# real shipped binary under a seccomp profile that reproduces those runtimes.
+# Revisit if Crystal grows a CLOCK_MONOTONIC fallback, and re-run that gate
+# before removing this.
+build_cmd="crystal build --release --no-debug --static -Devloop=libevent --cross-compile --target $target_platform"
 
 build_output=$(PKG_CONFIG_LIBDIR="$pkg_config_libdir" $build_cmd "$filename" -o "$object_file")
 


### PR DESCRIPTION
#### :zap: Summary

**v0.6.19, v0.6.20 and v0.6.21 cannot start at all in sandboxed container runtimes.** Even `coveralls --version` aborts:

```
Unhandled exception: timerfd_settime: Invalid argument (RuntimeError)
from ???
```

This affects gVisor and similar runtimes — the ones backing Cloud Run, GKE Autopilot, and several CI providers. It is **deterministic**: 100% of runs on an affected runtime, 0% everywhere else.

#### :mag: Root cause

Crystal 1.19 switched `timerfd_create()` from `CLOCK_MONOTONIC` to `CLOCK_BOOTTIME` (crystal-lang/crystal#16516, so monotonic clocks count suspended time). Sandboxed runtimes reimplement the kernel interface in software and cover `CLOCK_REALTIME`/`CLOCK_MONOTONIC` only, returning `EINVAL` for `CLOCK_BOOTTIME`.

Crystal builds its event loop *during startup*, so the process dies before `main()` — hence `--version` failing.

Two things made this hard to see:

- **The error names the wrong syscall.** The call that fails is `timerfd_create()`, but Crystal hardcodes `"timerfd_settime"` in the raise.
- **Crystal 1.21 reports it differently.** It hits the same wall one step earlier, during execution-context bootstrap, and surfaces `Thread#execution_context cannot be nil`.

That second point matters: **this is the same root cause as the original v0.6.19 report.** The SYSMON race fixed in #211 is a genuine upstream bug, but it is not the one these users were hitting. #211 was a correct fix for a problem they did not have.

#### :test_tube: Reproduction

A seccomp profile making `timerfd_create(CLOCK_BOOTTIME)` return `EINVAL` replays the entire reported history exactly, on both architectures:

| version | Crystal | result |
|---|---|---|
| 0.6.17 | 1.17.0 | ✅ |
| 0.6.18 | 1.17.1 | ✅ |
| 0.6.19 | 1.21.0 | ❌ `Thread#execution_context cannot be nil` |
| 0.6.20 | 1.21.0 | ❌ `Thread#execution_context cannot be nil` |
| 0.6.21 | 1.20.3 | ❌ `timerfd_settime: Invalid argument` |
| **this build** | 1.20.3 + libevent | ✅ |

Alpine is innocent — 3.20/3.22/3.24/edge all pass unmodified.

#### :hammer: Fix

Build with **`-Devloop=libevent`**, which does not use `timerfd` at all. This sidesteps the problem rather than trading one clock for another, and keeps us on Crystal 1.20.3 with **no source changes** — no `Time` API revert, no `shard.yml` change.

Considered and rejected: pinning Crystal to 1.18.2 (last version using `CLOCK_MONOTONIC`). It works, but needs reverting `Time.instant` → `Time.monotonic` plus the `shard.yml` constraint, and breaks a glob-ordering spec (149/1). Bigger diff, still depends on timerfd.

Tradeoff: libevent is Crystal's legacy loop. Mature — it was the default for years — but presumably deprecated eventually, so this is a workaround with a shelf life. Revisit if Crystal adds a `CLOCK_MONOTONIC` fallback.

#### :shield: Regression gate

The reason this shipped three times is that **ordinary CI cannot catch it** — GitHub runners and Docker Desktop use a real kernel where `CLOCK_BOOTTIME` timerfds work fine. I ran the v0.6.20 binary 440 times locally and it passed every time.

So this PR checks in the seccomp profile (`.github/seccomp/no-clock-boottime.json`) and wires it into `build.yml` as a gate that runs **the real shipped binary** under a simulated sandbox. Verified it discriminates: broken binary → exit 1, fixed binary → exit 0.

#### :ballot_box_with_check: Checklist

- [x] Add specs — n/a; this is a build-flag change. Coverage is the regression gate above, which tests the actual release artifact rather than a unit.